### PR TITLE
投稿作成・編集時のエラーメッセージを非同期で表示

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -126,8 +126,8 @@ a:hover {
   color: $silver;
 }
 
-.post-preview-image {
-  display: none;
+.post-file-field {
+  visibility: hidden;
 }
 
 .form-check label {

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -30,7 +30,7 @@
   max-height: 600px;
 }
 
-.preview-item {
+.preview-item, .edit-preview-item {
   position:relative;
   width: calc(100% / 2);
   padding-top: calc(100% / 2);

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -56,7 +56,7 @@
 .drop-container {
   position:relative;
   width: calc(100% / 2);
-  padding-top: calc((100% / 2) - 4px );
+  padding-top: calc((100% / 2) - 34px );
   margin: 0;
   background: $light-gray;
   border: 2px dashed $dark-gray;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -48,6 +48,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post_form).permit(:content, image: [], tag_ids: [], category_ids: [], delete_ids: [])
+    params.require(:post_form).permit(:content, images: [], tag_ids: [], category_ids: [], delete_ids: [])
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -21,18 +21,22 @@ class PostsController < ApplicationController
     @post = Post.new
     @post_form = PostForm.new(post_params.merge(user_id: current_user.id, post: @post))
     if @post_form.save
-      redirect_to posts_path, notice: '投稿しました'
+      flash[:notice] = '投稿しました'
+      # フォーマットが js のため JavaScript を使用してページ遷移
+      render js: "window.location.replace('#{posts_path}');"
     else
-      redirect_to posts_path, alert: 'エラーが発生しました'
+      render :create_error_messages
     end
   end
 
   def update
     @post_form = PostForm.new(post_params.merge(user_id: current_user.id, post: @post))
     if @post_form.save
-      redirect_to @post, notice: '投稿を編集しました'
+      flash[:notice] = '投稿を編集しました'
+      # フォーマットが js のため JavaScript を使用してページ遷移
+      render js: "window.location.replace('#{post_path(@post)}');"
     else
-      redirect_to @post, alert: '編集できませんでした'
+      render :update_error_messages
     end
   end
 

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -1,13 +1,13 @@
 class PostForm
   include ActiveModel::Model
 
-  attr_accessor :content, :image, :post, :tag_ids, :category_ids, :delete_ids, :user_id
+  attr_accessor :content, :images, :post, :tag_ids, :category_ids, :delete_ids, :user_id
 
   # Post モデルのバリデーション
   validates :content, presence: true, length: { maximum: 2000 }
   # Photo モデルのバリデーション
-  validates :image, presence: true, on: :create
-  validates :image, number_of_images: true
+  validates :images, presence: true, on: :create
+  validates :images, number_of_images: true
 
   validates :tag_ids, presence: true, length: { maximum: 2 }, custom_numericality: { allow_blank: true }
   validates :category_ids, presence: true, length: { maximum: 2 }, custom_numericality: { allow_blank: true }
@@ -34,8 +34,8 @@ class PostForm
         Photo.find(id.to_i).destroy!
       end
     end
-    if image.present?
-      image.each do |img|
+    if images.present?
+      images.each do |img|
         post.photos.build(image: img).save!
       end
     end
@@ -46,9 +46,9 @@ class PostForm
 
   def post_create
     post = Post.new(content: content, user_id: user_id, tag_ids: tag_ids, category_ids: category_ids)
-    return false if image.blank?
+    return false if images.blank?
 
-    image.each do |img|
+    images.each do |img|
       post.photos.build(image: img).save!
     end
   end

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -22,6 +22,8 @@ class PostForm
         post_create
       end
     end
+  rescue ActiveRecord::RecordInvalid
+    false
   end
 
   private

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -9,8 +9,8 @@ class PostForm
   validates :images, presence: true, on: :create
   validates :images, number_of_images: true
 
-  validates :tag_ids, presence: true, length: { maximum: 2 }, custom_numericality: { allow_blank: true }
-  validates :category_ids, presence: true, length: { maximum: 2 }, custom_numericality: { allow_blank: true }
+  validates :tag_ids, presence: true, length: { maximum: 2, message: 'は最大2つまで選択できます' }, custom_numericality: { allow_blank: true }
+  validates :category_ids, presence: true, length: { maximum: 2, message: 'は最大2つまで選択できます' }, custom_numericality: { allow_blank: true }
 
   def save
     return false if invalid?
@@ -22,7 +22,8 @@ class PostForm
         post_create
       end
     end
-  rescue ActiveRecord::RecordInvalid
+  rescue ActiveRecord::RecordInvalid => e
+    errors.add(:base, message: e.record.errors.full_messages)
     false
   end
 

--- a/app/javascript/packs/photos_preview.js
+++ b/app/javascript/packs/photos_preview.js
@@ -36,7 +36,7 @@ $(document).on('turbolinks:load', function () {
                         <button type="button" class="btn btn-dark-gray btn-sm rounded-circle delete-preview" data-action="${action}"><i class="fas fa-times"></i></button>
                       </div>`;
           $(`#${action}-drop`).before($(html));
-          const previewItemLength = $(`#${action}-drop`).prevAll('.preview-item').length;
+          const previewItemLength = $(`#${action}-drop`).prevAll("[class$='preview-item']").length;
           if ( previewItemLength >= 1 && previewItemLength <= 6 ) $(`#${action}-button`).prop('disabled', false);
           if ( previewItemLength >= 6 ){
             $(`#${action}-drop`).hide();
@@ -59,7 +59,7 @@ $(document).on('turbolinks:load', function () {
         dataBox = newDataBox
         fileField = new_file_field
       }
-      const targetImage = $(this).parents('.preview-item');
+      const targetImage = $(this).parents("[class$='preview-item']");
       const targetId = $(targetImage).data('id');
       $.each(fileField.files, function(i, file){
         if(file.id === targetId){
@@ -74,7 +74,7 @@ $(document).on('turbolinks:load', function () {
         $('#edit-drop').before(`<input type="hidden" name="post_form[delete_ids][]" value="${deleteId}">`);
       }
       targetImage.remove();
-      const previewItemLength = $(`#${action}-drop`).prevAll('.preview-item').length;
+      const previewItemLength = $(`#${action}-drop`).prevAll("[class$='preview-item']").length;
       if ( previewItemLength <= 6 ){
         $(`#${action}-button`).prop('disabled', false);
         if ( previewItemLength <= 5 ){
@@ -131,7 +131,7 @@ $(document).on('turbolinks:load', function () {
                         <button type="button" class="btn btn-dark-gray btn-sm rounded-circle delete-preview" data-action="${action}"><i class="fas fa-times"></i></button>
                       </div>`;
             $(`#${action}-drop`).before($(html));
-            const previewItemLength = $(`#${action}-drop`).prevAll('.preview-item').length;
+            const previewItemLength = $(`#${action}-drop`).prevAll("[class$='preview-item']").length;
             if ( previewItemLength >= 1 && previewItemLength <= 6){
               $(`#${action}-button`).prop('disabled', false);
                 if ( previewItemLength >= 6 ){

--- a/app/javascript/packs/photos_preview.js
+++ b/app/javascript/packs/photos_preview.js
@@ -4,7 +4,6 @@ $(document).on('turbolinks:load', function () {
     let edit_file_field = document.querySelector('input[data-action=edit]');
     let newDataBox = new DataTransfer();
     let new_file_field = document.querySelector('input[data-action=new]');
-    $('#new-button').prop('disabled', true);
     // 画像選択時にプレビューを表示
     $('.post-preview-image').on("change", function(){
       let dataBox, fileField
@@ -37,12 +36,14 @@ $(document).on('turbolinks:load', function () {
                       </div>`;
           $(`#${action}-drop`).before($(html));
           const previewItemLength = $(`#${action}-drop`).prevAll("[class$='preview-item']").length;
-          if ( previewItemLength >= 1 && previewItemLength <= 6 ) $(`#${action}-button`).prop('disabled', false);
-          if ( previewItemLength >= 6 ){
-            $(`#${action}-drop`).hide();
-            if ( previewItemLength === 7 ){
-              $(`#${action}-button`).prop('disabled', true);
-              alert('画像は最大 6枚 にしてください');
+          if (previewItemLength > 0){
+            $("[id$='post_form_images-error']").css('display', 'none');
+            if ( previewItemLength >= 6 ){
+              $(`#${action}-drop`).hide();
+              if ( previewItemLength === 7 ){
+                $(`#${action}-button`).prop('disabled', true);
+                alert('画像は最大 6枚 にしてください');
+              }
             }
           }
         };
@@ -80,7 +81,7 @@ $(document).on('turbolinks:load', function () {
         if ( previewItemLength <= 5 ){
           $(`#${action}-drop`).show();
           if ( previewItemLength === 0 ){
-            $(`#${action}-button`).prop('disabled', true);
+            $("[id$='post_form_images-error']").css('display', 'block');
           }
         }
       }
@@ -132,9 +133,9 @@ $(document).on('turbolinks:load', function () {
                       </div>`;
             $(`#${action}-drop`).before($(html));
             const previewItemLength = $(`#${action}-drop`).prevAll("[class$='preview-item']").length;
-            if ( previewItemLength >= 1 && previewItemLength <= 6){
-              $(`#${action}-button`).prop('disabled', false);
-                if ( previewItemLength >= 6 ){
+            if (previewItemLength > 0){
+              $("[id$='post_form_images-error']").css('display', 'none');
+              if ( previewItemLength >= 6 ){
                 $(`#${action}-drop`).hide();
                 if ( previewItemLength === 7 ){
                   $(`#${action}-button`).prop('disabled', true);

--- a/app/javascript/packs/photos_preview.js
+++ b/app/javascript/packs/photos_preview.js
@@ -4,6 +4,8 @@ $(document).on('turbolinks:load', function () {
     let edit_file_field = document.querySelector('input[data-action=edit]');
     let newDataBox = new DataTransfer();
     let new_file_field = document.querySelector('input[data-action=new]');
+    const maxFileSize = 1048576 * 5;
+    const mimeType = ['image/jpeg', 'image/png'];
     // 画像選択時にプレビューを表示
     $('.post-file-field').on("change", function(){
       let dataBox, fileField
@@ -15,38 +17,46 @@ $(document).on('turbolinks:load', function () {
         dataBox = newDataBox
         fileField = new_file_field
       }
-        // 選択をキャンセルした場合の処理
+      // 選択をキャンセルした場合の処理
       if ($(this).val() === "") {
         $('.preview-item').remove();
         fileField.files = dataBox.files
         dataBox.clearData();
       }
-      const files = $('input[type="file"]').prop('files')[0];
-      $.each(this.files, function(i, file){
-        const fileReader = new FileReader();
-        const lastFileId = dataBox.files.length === 0 ? 0 : $(dataBox.files).last()[0].id;
-        file.id = lastFileId + 1;
-        dataBox.items.add(file);
-        fileField.files = dataBox.files
-        fileReader.readAsDataURL(file);
-        fileReader.onloadend = function() {
-          const html = `<div class="preview-item" data-id="${file.id}">
-                        <img src="${fileReader.result}" class="preview-image">
-                        <button type="button" class="btn btn-dark-gray btn-sm rounded-circle delete-preview" data-action="${action}"><i class="fas fa-times"></i></button>
-                      </div>`;
-          $(`#${action}-drop`).before($(html));
-          const previewItemLength = $(`#${action}-drop`).prevAll("[class$='preview-item']").length;
-          if (previewItemLength > 0){
-            $("[id$='post_form_images-error']").css('display', 'none');
-            if ( previewItemLength >= 6 ){
-              $(`#${action}-drop`).hide();
-              if ( previewItemLength === 7 ){
-                $(`#${action}-button`).prop('disabled', true);
-                alert('画像は最大 6枚 にしてください');
+      const files = $(this).prop('files');
+      $.each(files, function(i, file){
+        if(maxFileSize < file.size){
+          // 画像ファイルが 5MB より大きい場合の処理
+          alert('画像ファイルは最大 5MB 以下にしてください');
+        } else if (!mimeType.includes(file.type)){
+          // 画像ファイルが .jpeg, .jpg, .png 以外の場合の処理
+          alert('画像ファイルは .jpg, .jpeg, .png のみアップロードできます');
+        } else {
+          const fileReader = new FileReader();
+          const lastFileId = dataBox.files.length === 0 ? 0 : $(dataBox.files).last()[0].id;
+          file.id = lastFileId + 1;
+          dataBox.items.add(file);
+          fileField.files = dataBox.files
+          fileReader.readAsDataURL(file);
+          fileReader.onloadend = function() {
+            const html = `<div class="preview-item" data-id="${file.id}">
+                          <img src="${fileReader.result}" class="preview-image">
+                          <button type="button" class="btn btn-dark-gray btn-sm rounded-circle delete-preview" data-action="${action}"><i class="fas fa-times"></i></button>
+                        </div>`;
+            $(`#${action}-drop`).before($(html));
+            const previewItemLength = $(`#${action}-drop`).prevAll("[class$='preview-item']").length;
+            if (previewItemLength > 0){
+              $("[id$='post_form_images-error']").css('display', 'none');
+              if ( previewItemLength >= 6 ){
+                $(`#${action}-drop`).hide();
+                if ( previewItemLength === 7 ){
+                  $(`#${action}-button`).prop('disabled', true);
+                  alert('画像は最大 6枚 にしてください');
+                }
               }
             }
-          }
-        };
+          };
+        }
       });
     });
     // 画像の削除
@@ -120,30 +130,38 @@ $(document).on('turbolinks:load', function () {
         $(this).css({'border': '2px dashed $dark-gray', 'opacity': '1.0'});
         const files = e.dataTransfer.files;
         $.each(files, function(i, file){
-          const fileReader = new FileReader();
-          const lastFileId = dataBox.files.length === 0 ? 0 : $(dataBox.files).last()[0].id;
-          file.id = lastFileId + 1;
-          dataBox.items.add(file)
-          fileField.files = dataBox.files
-          fileReader.readAsDataURL(file);
-          fileReader.onloadend = function() {
-            const html = `<div class="preview-item" data-id="${file.id}">
-                        <img src="${fileReader.result}" class="preview-image">
-                        <button type="button" class="btn btn-dark-gray btn-sm rounded-circle delete-preview" data-action="${action}"><i class="fas fa-times"></i></button>
-                      </div>`;
-            $(`#${action}-drop`).before($(html));
-            const previewItemLength = $(`#${action}-drop`).prevAll("[class$='preview-item']").length;
-            if (previewItemLength > 0){
-              $("[id$='post_form_images-error']").css('display', 'none');
-              if ( previewItemLength >= 6 ){
-                $(`#${action}-drop`).hide();
-                if ( previewItemLength === 7 ){
-                  $(`#${action}-button`).prop('disabled', true);
-                  alert('画像は最大 6枚 にしてください');
+          if(maxFileSize < file.size){
+            // 画像ファイルが 5MB より大きい場合の処理
+            alert('画像ファイルは最大 5MB 以下にしてください');
+          } else if (!mimeType.includes(file.type)){
+            // 画像ファイルが .jpeg, .jpg, .png 以外の場合の処理
+            alert('画像ファイルは .jpg, .jpeg, .png のみアップロードできます');
+          } else {
+            const fileReader = new FileReader();
+            const lastFileId = dataBox.files.length === 0 ? 0 : $(dataBox.files).last()[0].id;
+            file.id = lastFileId + 1;
+            dataBox.items.add(file)
+            fileField.files = dataBox.files
+            fileReader.readAsDataURL(file);
+            fileReader.onloadend = function() {
+              const html = `<div class="preview-item" data-id="${file.id}">
+                          <img src="${fileReader.result}" class="preview-image">
+                          <button type="button" class="btn btn-dark-gray btn-sm rounded-circle delete-preview" data-action="${action}"><i class="fas fa-times"></i></button>
+                        </div>`;
+              $(`#${action}-drop`).before($(html));
+              const previewItemLength = $(`#${action}-drop`).prevAll("[class$='preview-item']").length;
+              if (previewItemLength > 0){
+                $("[id$='post_form_images-error']").css('display', 'none');
+                if ( previewItemLength >= 6 ){
+                  $(`#${action}-drop`).hide();
+                  if ( previewItemLength === 7 ){
+                    $(`#${action}-button`).prop('disabled', true);
+                    alert('画像は最大 6枚 にしてください');
+                  }
                 }
               }
-            }
-          };
+            };
+          }
         });
       });
     });

--- a/app/javascript/packs/photos_preview.js
+++ b/app/javascript/packs/photos_preview.js
@@ -5,7 +5,7 @@ $(document).on('turbolinks:load', function () {
     let newDataBox = new DataTransfer();
     let new_file_field = document.querySelector('input[data-action=new]');
     // 画像選択時にプレビューを表示
-    $('.post-preview-image').on("change", function(){
+    $('.post-file-field').on("change", function(){
       let dataBox, fileField
       const action = $(this).data('action');
       if (action === "edit") {

--- a/app/javascript/packs/post_edit.js
+++ b/app/javascript/packs/post_edit.js
@@ -8,7 +8,7 @@ $(document).on('turbolinks:load', function() {
       // 投稿内容を表示
       $('#edit_post_form_content').val(content)
       // 投稿画像を表示
-      const previewData = $('#edit-drop').prevAll('.preview-item');
+      const previewData = $('#edit-drop').prevAll('.edit-preview-item');
       const targetIds = $.map(previewData, function(preview) {
         return $(preview).data('id');
       });
@@ -18,12 +18,12 @@ $(document).on('turbolinks:load', function() {
       if (targetIds.toString() !== photoIds.toString()) {
         $('#edit-drop').prevAll().remove();
         photos.forEach(function(photo){
-        const html = `<div class="preview-item" data-id="photos-${photo.id}">
+        const html = `<div class="edit-preview-item" data-id="photos-${photo.id}">
                         <img src="${photo.image.url}" class="preview-image">
                         <button type="button" class="btn btn-dark-gray btn-sm rounded-circle delete-preview" data-action="edit"><i class="fas fa-times"></i></button>
                       </div>`;
           $('#edit-drop').before($(html));
-          const previewItemLength = $('#edit-drop').prevAll('.preview-item').length;
+          const previewItemLength = $('#edit-drop').prevAll('.edit-preview-item').length;
           if ( previewItemLength >= 1 && previewItemLength <= 6 ) {
             $('#edit-button').prop('disabled', false);
             if ( previewItemLength === 6 ) {

--- a/app/javascript/packs/validate_rules.js
+++ b/app/javascript/packs/validate_rules.js
@@ -17,6 +17,11 @@ $(document).on('turbolinks:load', function(){
           "post_form[category_ids][]": {
             required: true,
             maxlength: 2
+          },
+          "post_form[images][]": {
+            required: function() {
+              return $('.preview-image').length  == 0
+            }
           }
         },
         messages: {
@@ -31,6 +36,9 @@ $(document).on('turbolinks:load', function(){
           "post_form[category_ids][]": {
             required: '※ カテゴリーを選択してください',
             maxlength: '※ カテゴリは2つまで選択できます'
+          },
+          "post_form[images][]": {
+            required: '※ 画像を選択して下さい'
           }
         },
         errorElement: 'div',

--- a/app/javascript/packs/validate_rules.js
+++ b/app/javascript/packs/validate_rules.js
@@ -21,27 +21,21 @@ $(document).on('turbolinks:load', function(){
         },
         messages: {
           "post_form[content]": {
-            required: '* 投稿内容を入力してください',
-            maxlength: '* 2000文字以内で入力してください'
+            required: '※ キャプションを入力してください',
+            maxlength: '※ 2000文字以内で入力してください'
           },
           "post_form[tag_ids][]": {
-            required: '* タグを選択してください',
-            maxlength: '* タグは2つまで選択できます'
+            required: '※ タグを選択してください',
+            maxlength: '※ タグは2つまで選択できます'
           },
           "post_form[category_ids][]": {
-            required: '* カテゴリーを選択してください',
-            maxlength: '* カテゴリは2つまで選択できます'
+            required: '※ カテゴリーを選択してください',
+            maxlength: '※ カテゴリは2つまで選択できます'
           }
         },
         errorElement: 'div',
         errorPlacement: function(error, element){
-          if(element.attr('name') === 'post_form[tag_ids][]'){
-            error.insertAfter(element.parents('.tag-group'));
-          } else if(element.attr('name') === 'post_form[category_ids][]'){
-            error.insertAfter(element.parents('.category-group'));
-          } else {
-            error.insertAfter(element);
-          }
+          error.insertAfter(element.closest('.form-group'));
         }
       });
     });

--- a/app/validators/custom_numericality_validator.rb
+++ b/app/validators/custom_numericality_validator.rb
@@ -1,8 +1,9 @@
 class CustomNumericalityValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     value.each do |v|
-      if (attribute == :tag_ids && v.to_i > 18) || (attribute == :category_ids && v.to_i > 18)
-        record.errors.add attribute, (options[:message] || '入力された値は存在しません')
+      if (attribute == :tag_ids && Tag.ids.exclude?(v.to_i)) || (attribute == :category_ids && Category.ids.exclude?(v.to_i))
+        record.errors.add attribute, (options[:message] || 'は選択肢の中から選んで下さい')
+        break
       end
     end
   end

--- a/app/validators/number_of_images_validator.rb
+++ b/app/validators/number_of_images_validator.rb
@@ -1,7 +1,11 @@
 class NumberOfImagesValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     total_number_of_images = record.post.photos.length + number_of_images_to_add(value) - number_of_images_to_delete(record)
-    record.errors.add attribute, (options[:message] || 'は最大6枚まで選択できます') if total_number_of_images > 6 || total_number_of_images.zero?
+    if total_number_of_images.zero?
+      record.errors.add attribute, (options[:message] || 'を選択してください')
+    elsif total_number_of_images > 6
+      record.errors.add attribute, (options[:message] || 'は最大6枚まで選択できます')
+    end
   end
 
   def number_of_images_to_add(value)

--- a/app/views/posts/create_error_messages.js.erb
+++ b/app/views/posts/create_error_messages.js.erb
@@ -1,0 +1,2 @@
+document.getElementById('post-create-error-messages').innerHTML = '<%= j render("layouts/error_messages", model: @post_form) %>';
+document.getElementById('post-create-error-messages').scrollIntoView();

--- a/app/views/posts/update_error_messages.js.erb
+++ b/app/views/posts/update_error_messages.js.erb
@@ -1,0 +1,2 @@
+document.getElementById('post-update-error-messages').innerHTML = '<%= j render("layouts/error_messages", model: @post_form) %>';
+document.getElementById('post-update-error-messages').scrollIntoView();

--- a/app/views/shared/_edit_modal_content.html.erb
+++ b/app/views/shared/_edit_modal_content.html.erb
@@ -11,7 +11,7 @@
   <div class="form-group mt-3">
     <div class="preview-box d-flex flex-wrap">
       <%= form.label :images, class: 'drop-container', id: 'edit-drop' do %>
-        <%= form.file_field :images, multiple: true, class: 'form-control-file post-preview-image', accept: 'image/png, image/jpeg, image/jpg', type: "file", data: { action: "edit" } %>
+        <%= form.file_field :images, multiple: true, class: 'form-control-file post-file-field', accept: 'image/png, image/jpeg, image/jpg', type: "file", data: { action: "edit" } %>
         <i class="far fa-image" id="drop-container-icon" ></i>
       <% end %>
     </div>

--- a/app/views/shared/_edit_modal_content.html.erb
+++ b/app/views/shared/_edit_modal_content.html.erb
@@ -18,7 +18,7 @@
   </div>
   <small>* 最大6枚まで投稿できます *</small>
   <hr>
-  <div class="form-group mt-3 tag-group">
+  <div class="form-group mt-3">
     <i class="fas fa-tag tag-color"></i>
     <span class="font-weight-bold">タグ</span>
     <ul class="row px-3">
@@ -36,7 +36,7 @@
   </div>
   <small>* 最大2つまで選択可能です *</small>
   <hr>
-  <div class="form-group mt-3 category-group">
+  <div class="form-group mt-3">
     <i class="fas fa-folder category-color"></i>
     <span class="font-weight-bold">カテゴリ</span>
     <ul class="row px-3">

--- a/app/views/shared/_edit_modal_content.html.erb
+++ b/app/views/shared/_edit_modal_content.html.erb
@@ -7,8 +7,8 @@
   <hr>
   <div class="form-group mt-3">
     <div class="preview-box d-flex flex-wrap">
-      <%= form.label :image, class: 'drop-container', id: 'edit-drop' do %>
-        <%= form.file_field :image, multiple: true, class: 'form-control-file post-preview-image', accept: 'image/png, image/jpeg, image/jpg', type: "file", data: { action: "edit" } %>
+      <%= form.label :images, class: 'drop-container', id: 'edit-drop' do %>
+        <%= form.file_field :images, multiple: true, class: 'form-control-file post-preview-image', accept: 'image/png, image/jpeg, image/jpg', type: "file", data: { action: "edit" } %>
         <i class="far fa-image" id="drop-container-icon" ></i>
       <% end %>
     </div>

--- a/app/views/shared/_edit_modal_content.html.erb
+++ b/app/views/shared/_edit_modal_content.html.erb
@@ -1,4 +1,7 @@
-<%= form_with model: PostForm.new, url: post_path, class: 'post-form', method: :patch, namespace: 'edit', local: true do |form| %>
+<%= form_with model: PostForm.new, url: post_path, class: 'post-form', method: :patch, namespace: 'edit', local: false do |form| %>
+  <div id="post-update-error-messages">
+    <%= render "layouts/error_messages", model: form.object %>
+  </div>
   <div class="form-group mt-3">
     <%= form.label :content, 'キャプション', class: 'font-weight-bold' %>
     <%= form.text_area :content, class: 'form-control', rows: '10', maxlength: 2000 %>

--- a/app/views/shared/_new_modal_content.html.erb
+++ b/app/views/shared/_new_modal_content.html.erb
@@ -18,7 +18,7 @@
   </div>
   <small>* 最大6枚まで投稿できます *</small>
   <hr>
-  <div class="form-group mt-3 tag-group">
+  <div class="form-group mt-3">
     <i class="fas fa-tag tag-color"></i>
     <span class="font-weight-bold">タグ</span>
     <ul class="row px-3">
@@ -36,7 +36,7 @@
   </div>
   <small>* 最大2つまで選択可能です *</small>
   <hr>
-  <div class="form-group mt-3 category-group">
+  <div class="form-group mt-3">
     <i class="fas fa-folder category-color"></i>
     <span class="font-weight-bold">カテゴリ</span>
     <ul class="row px-3">

--- a/app/views/shared/_new_modal_content.html.erb
+++ b/app/views/shared/_new_modal_content.html.erb
@@ -7,8 +7,8 @@
   <hr>
   <div class="form-group mt-3">
     <div class="preview-box d-flex flex-wrap">
-      <%= form.label :image, class: "drop-container", id: "new-drop" do %>
-        <%= form.file_field :image, multiple: true, class: 'form-control-file post-preview-image', accept: 'image/png, image/jpeg, image/jpg', required: true, type: "file", data: {action: "new"} %>
+      <%= form.label :images, class: "drop-container", id: "new-drop" do %>
+        <%= form.file_field :images, multiple: true, class: 'form-control-file post-preview-image', accept: 'image/png, image/jpeg, image/jpg', required: true, type: "file", data: {action: "new"} %>
         <i class="far fa-image" id="drop-container-icon" ></i>
       <% end %>
     </div>

--- a/app/views/shared/_new_modal_content.html.erb
+++ b/app/views/shared/_new_modal_content.html.erb
@@ -11,7 +11,7 @@
   <div class="form-group mt-3">
     <div class="preview-box d-flex flex-wrap">
       <%= form.label :images, class: "drop-container", id: "new-drop" do %>
-        <%= form.file_field :images, multiple: true, class: 'form-control-file post-preview-image', accept: 'image/png, image/jpeg, image/jpg', required: true, type: "file", data: {action: "new"} %>
+        <%= form.file_field :images, multiple: true, class: 'form-control-file post-file-field', accept: 'image/png, image/jpeg, image/jpg', required: true, type: "file", data: {action: "new"} %>
         <i class="far fa-image" id="drop-container-icon" ></i>
       <% end %>
     </div>

--- a/app/views/shared/_new_modal_content.html.erb
+++ b/app/views/shared/_new_modal_content.html.erb
@@ -1,4 +1,7 @@
-<%= form_with model: PostForm.new, url: posts_path, class: 'post-form', namespace: 'new', local: true do |form| %>
+<%= form_with model: PostForm.new, url: posts_path, class: 'post-form', namespace: 'new', local: false do |form| %>
+  <div id="post-create-error-messages">
+    <%= render "layouts/error_messages", model: form.object %>
+  </div>
   <div class="form-group mt-3">
     <%= form.label :content, 'キャプション', class: "font-weight-bold" %>
     <%= form.text_area :content, class: 'form-control', rows: '10', maxlength: 2000 %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -69,6 +69,13 @@ ja:
       progress:
         user: ユーザー
         know_how: ノウハウ
+  activemodel:
+    attributes:
+      post_form:
+        content: キャプション
+        images: 画像
+        tag_ids: タグ
+        category_ids: カテゴリ
   views:
     pagination:
       first: "&laquo;"
@@ -76,4 +83,3 @@ ja:
       previous: "&lsaquo;"
       next: "&rsaquo;"
       truncate: "&hellip;"
-

--- a/spec/factories/post_forms.rb
+++ b/spec/factories/post_forms.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :post_form do
     post { Post.new }
     content { Faker::Lorem.paragraph }
-    image { [Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/test.jpg'))] }
+    images { [Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/test.jpg'))] }
     tag_ids { [1, 2] }
     category_ids { [1, 2] }
   end

--- a/spec/forms/post_form_spec.rb
+++ b/spec/forms/post_form_spec.rb
@@ -75,24 +75,24 @@ RSpec.describe PostForm, type: :model do
       end
     end
 
-    context 'image が空のとき' do
-      let(:post_form) { build(:post_form, image: '') }
+    context 'images が空のとき' do
+      let(:post_form) { build(:post_form, images: '') }
       it 'エラーが発生する' do
         expect(post_form.valid?(:create)).to eq false
-        expect(post_form.errors.messages[:image]).to include 'を入力してください'
+        expect(post_form.errors.messages[:images]).to include 'を入力してください'
       end
     end
 
-    context 'image が6枚以上のとき' do
+    context 'images が6枚以上のとき' do
       before do
         @images = []
         7.times { @images << Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/test.jpg')) }
       end
 
-      let(:post_form) { build(:post_form, image: @images) }
+      let(:post_form) { build(:post_form, images: @images) }
       it 'エラーが発生する' do
         expect(post_form.valid?(:create)).to eq false
-        expect(post_form.errors.messages[:image]).to include 'は最大6枚まで選択できます'
+        expect(post_form.errors.messages[:images]).to include 'は最大6枚まで選択できます'
       end
     end
   end
@@ -118,7 +118,7 @@ RSpec.describe PostForm, type: :model do
       end
 
       context '画像が1つも選択されていない場合' do
-        let(:post_form) { build(:post_form, post: post, delete_ids: [2], image: '') }
+        let(:post_form) { build(:post_form, post: post, delete_ids: [2], images: '') }
         it '更新されないこと' do
           expect { subject }.to change { post.photos.count }.by(0)
         end
@@ -134,7 +134,7 @@ RSpec.describe PostForm, type: :model do
       end
 
       context '画像が選択されていない場合' do
-        let(:post_form) { build(:post_form, user_id: user.id, image: '') }
+        let(:post_form) { build(:post_form, user_id: user.id, images: '') }
         it 'エラーが発生すること' do
           expect(subject).to eq false
         end

--- a/spec/forms/post_form_spec.rb
+++ b/spec/forms/post_form_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe PostForm, type: :model do
   describe 'バリデーション' do
     subject { post_form.valid? }
 
+    before do
+      FactoryBot.rewind_sequences
+      create_list(:tag, 3)
+      create_list(:category, 3)
+    end
+
     context 'データが条件を満たすとき' do
       let(:post_form) { build(:post_form) }
       it '保存できること' do
@@ -39,15 +45,15 @@ RSpec.describe PostForm, type: :model do
       let(:post_form) { build(:post_form, tag_ids: [1, 2, 3]) }
       it 'エラーが発生すること' do
         expect(subject).to eq false
-        expect(post_form.errors.messages[:tag_ids]).to include 'は2文字以内で入力してください'
+        expect(post_form.errors.messages[:tag_ids]).to include 'は最大2つまで選択できます'
       end
     end
 
-    context 'tag_ids の値が18以上のとき' do
-      let(:post_form) { build(:post_form, tag_ids: [19]) }
+    context 'tag_ids の値と同じ id のタグが存在しない場合' do
+      let(:post_form) { build(:post_form, tag_ids: [4]) }
       it 'エラーが発生すること' do
         expect(subject).to eq false
-        expect(post_form.errors.messages[:tag_ids]).to include '入力された値は存在しません'
+        expect(post_form.errors.messages[:tag_ids]).to include 'は選択肢の中から選んで下さい'
       end
     end
 
@@ -63,15 +69,15 @@ RSpec.describe PostForm, type: :model do
       let(:post_form) { build(:post_form, category_ids: [1, 2, 3]) }
       it 'エラーが発生すること' do
         expect(subject).to eq false
-        expect(post_form.errors.messages[:category_ids]).to include 'は2文字以内で入力してください'
+        expect(post_form.errors.messages[:category_ids]).to include 'は最大2つまで選択できます'
       end
     end
 
-    context 'categoryr_ids の値が18以上のとき' do
-      let(:post_form) { build(:post_form, category_ids: [19]) }
+    context 'categoryr_ids の値と同じ id のカテゴリが存在しない場合' do
+      let(:post_form) { build(:post_form, category_ids: [4]) }
       it 'エラーが発生すること' do
         expect(subject).to eq false
-        expect(post_form.errors.messages[:category_ids]).to include '入力された値は存在しません'
+        expect(post_form.errors.messages[:category_ids]).to include 'は選択肢の中から選んで下さい'
       end
     end
 
@@ -79,7 +85,7 @@ RSpec.describe PostForm, type: :model do
       let(:post_form) { build(:post_form, images: '') }
       it 'エラーが発生する' do
         expect(post_form.valid?(:create)).to eq false
-        expect(post_form.errors.messages[:images]).to include 'を入力してください'
+        expect(post_form.errors.messages[:images]).to include 'を選択してください'
       end
     end
 
@@ -116,13 +122,6 @@ RSpec.describe PostForm, type: :model do
           expect(subject).to eq true
         end
       end
-
-      context '画像が1つも選択されていない場合' do
-        let(:post_form) { build(:post_form, post: post, delete_ids: [2], images: '') }
-        it '更新されないこと' do
-          expect { subject }.to change { post.photos.count }.by(0)
-        end
-      end
     end
 
     describe '#post_create' do
@@ -132,12 +131,21 @@ RSpec.describe PostForm, type: :model do
           expect { subject }.to change { user.posts.count }.by(1)
         end
       end
+    end
 
-      context '画像が選択されていない場合' do
-        let(:post_form) { build(:post_form, user_id: user.id, images: '') }
-        it 'エラーが発生すること' do
-          expect(subject).to eq false
-        end
+    context '画像ファイルサイズが 5MB より大きいのとき' do
+      let(:post_form) { build(:post_form, images: [Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/rspec_size_test.jpg'))]) }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(post_form.errors.full_messages).to include 'Imageファイルを5MBバイト以下のサイズにしてください'
+      end
+    end
+
+    context '画像ファイルタイプが jpg, jpeg, png 以外のとき' do
+      let(:post_form) { build(:post_form, images: [Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/rspec_extension_test.tiff'))]) }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(post_form.errors.full_messages).to include 'Image"tiff"ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: jpg, jpeg, png'
       end
     end
   end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe '投稿機能', type: :system do
             click_on '投稿する'
           end
           fill_in 'キャプション', with: post.content
-          attach_file('post_form[image][]', Rails.root.join('spec/fixtures/test.jpg'), make_visible: true)
+          attach_file('post_form[images][]', Rails.root.join('spec/fixtures/test.jpg'), make_visible: true)
           within '.tag-group' do
             all('label')[0].click
           end
@@ -67,7 +67,7 @@ RSpec.describe '投稿機能', type: :system do
             click_on '投稿する'
           end
           expect(page).to have_button '投稿する', disabled: true
-          attach_file('post_form[image][]', Rails.root.join('spec/fixtures/test.jpg'), make_visible: true)
+          attach_file('post_form[images][]', Rails.root.join('spec/fixtures/test.jpg'), make_visible: true)
           find('#new-button').click
           expect(page).to have_content '* 投稿内容を入力してください'
           expect(page).to have_content '* タグを選択してください'
@@ -83,7 +83,7 @@ RSpec.describe '投稿機能', type: :system do
             click_on '投稿する'
           end
           fill_in 'キャプション', with: post.content
-          attach_file('post_form[image][]', Rails.root.join('spec/fixtures/test.jpg'), make_visible: true)
+          attach_file('post_form[images][]', Rails.root.join('spec/fixtures/test.jpg'), make_visible: true)
           within '.tag-group' do
             all('label')[0].click
             all('label')[1].click
@@ -136,7 +136,7 @@ RSpec.describe '投稿機能', type: :system do
           expect(page).to have_unchecked_field(@category.name, visible: :hidden)
           # 内容の更新
           fill_in 'キャプション', with: updated_post.content
-          attach_file('post_form[image][]', Rails.root.join('spec/fixtures/test_2.jpg'), make_visible: true)
+          attach_file('post_form[images][]', Rails.root.join('spec/fixtures/test_2.jpg'), make_visible: true)
           find("label[for='edit_post_form_tag_ids_#{@tag.id}']").click
           find("label[for='edit_post_form_category_ids_#{@category.id}']").click
         end


### PR DESCRIPTION
close #203
  
## 実装内容
- 投稿画像保存時に例外ではなく`false`が返るように修正
- フォームオブジェクトで設定している画像の属性値を`images`に変更
- 投稿画像の`コントローラ`, `ビュー`, `フォームオブジェクト`の属性値を`images`に変更
- 投稿編集で画像選択後に再度画像選択画面を開きキャンセルボタンを押下した後、登録済みの画像プレビューが表示されなくなってしまっていたのを修正
- `jQuery Validation Plugin` のエラーメッセージとその表示位置を修正
- `jQuery Validation Plugin`を使用して`post_form[images][]`にバリデーションルールとエラーメッセージを追加
  - `.preview-image`を持つオブジェクト(プレビュー画像)がない場合、エラーメッセージを表示
- タグ・カテゴリのカスタムバリデーションでテーブルに保存されている`id`と一致する`id`が存在しない場合はエラーメッセージを追加するように変更
- 投稿画像枚数のカスタムバリデーションで枚数が`0枚`と`6枚以上`のときで追加するエラーメッセージの内容を変更
- フォームオブジェクトのバリデーションエラーメッセージをモーダル上部に非同期で表示するように設定
  - バリデーションエラーメッセージを非同期で表示するために`create_error_messages.js.erb`, `update_error_messages.js.erb`を追加
  - バリデーション通過時、フォーマットが js のため JavaScript を使用してページ遷移するように設定
  ```rb
  render js: "window.location.replace('遷移先のページ URL');"
  ```
- 投稿画像フィールドのclass属性を`post-preview-image`から`post-file-field`に修正
- 投稿画像フィールドの非表示設定を`display: none;`ではなく`visibility: hidden;`に修正
- 画像アップロードの際にファイルサイズが`5MB`より大きい時、アップロードせずにアラートを表示
- 画像アップロードの際にファイルタイプが`image/jpeg`, `image/png`以外の場合、アップロードせずにアラートを表示
- 投稿のシステムスペック、フォームオブジェクトのモデルスペックを修正
  - エラーメッセージの内容を修正
  - タグ・カテゴリ選択のエクスペクテーションを修正
  - 画像サイズが5MBより大きいの場合のテストを追加
  - 画像タイプが jpg, jpeg, png 以外の場合のテストを追加
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec/forms spec/models spec/system`を実行