### PR TITLE
お問い合わせ機能のシステムスペックを追加

### DIFF
--- a/app/models/concerns/confirmable.rb
+++ b/app/models/concerns/confirmable.rb
@@ -9,15 +9,12 @@ module Confirmable
     private
 
     def confirming
-      # 確認ボタン押下して入力エラーが無い場合
-      if submitted == '' && errors.keys == [:submitted]
-        self.submitted = '1'
-        errors.delete :submitted
-      end
+      # 確認ボタン押下した際に、入力エラーが無い場合
+      self.submitted = '1' if submitted == '' && errors.keys == [:submitted]
       # 戻るボタンを押下した場合
-      return unless confirmed == ''
+      self.submitted = '' if confirmed == ''
 
-      self.submitted = ''
+      errors.delete :submitted
       errors.delete :confirmed
     end
   end

--- a/spec/system/inquiries_spec.rb
+++ b/spec/system/inquiries_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe 'お問い合わせ機能', type: :system do
+  let(:inquiry) { build(:inquiry) }
+  before do
+    visit root_path
+    first('footer').click_on 'お問い合わせ'
+    fill_in 'お客様のお名前', with: inquiry.name
+    fill_in 'お客様のお名前(カナ)', with: inquiry.name_kana
+    fill_in 'メールアドレス', with: inquiry.email
+    fill_in 'お問い合わせ内容', with: inquiry.content
+  end
+
+  describe '入力画面' do
+    context '入力内容が条件を満たすとき' do
+      it '確認画面に遷移し、入力した内容が表示されていること' do
+        expect do
+          expect(find('#inquiry_submitted', visible: false).value).to eq nil
+          click_on '入力内容を確認'
+          expect(find('#inquiry_submitted', visible: false).value).to eq '1'
+          expect(find_field('お客様のお名前').readonly?).to eq true
+          expect(find_field('お客様のお名前').value).to eq inquiry.name
+          expect(find_field('お客様のお名前(カナ)').readonly?).to eq true
+          expect(find_field('お客様のお名前(カナ)').value).to eq inquiry.name_kana
+          expect(find_field('メールアドレス').readonly?).to eq true
+          expect(find_field('メールアドレス').value).to eq inquiry.email
+          expect(find_field('お問い合わせ内容').readonly?).to eq true
+          expect(find_field('お問い合わせ内容').value).to eq inquiry.content
+        end.to change(Inquiry, :count).by(0)
+      end
+    end
+  end
+
+  describe '確認画面' do
+    context '【入力画面に戻る】ボタンを押下したとき' do
+      it '入力画面に遷移し、入力した内容が表示されていること' do
+        expect do
+          expect(find('#inquiry_submitted', visible: false).value).to eq nil
+          click_on '入力内容を確認'
+          click_on '入力画面に戻る'
+          expect(find('#inquiry_submitted', visible: false).value).to eq ''
+          expect(find_field('お客様のお名前').readonly?).to eq false
+          expect(find_field('お客様のお名前').value).to eq inquiry.name
+          expect(find_field('お客様のお名前(カナ)').readonly?).to eq false
+          expect(find_field('お客様のお名前(カナ)').value).to eq inquiry.name_kana
+          expect(find_field('メールアドレス').readonly?).to eq false
+          expect(find_field('メールアドレス').value).to eq inquiry.email
+          expect(find_field('お問い合わせ内容').readonly?).to eq false
+          expect(find_field('お問い合わせ内容').value).to eq inquiry.content
+        end.to change(Inquiry, :count).by(0)
+      end
+    end
+
+    context '【この内容で送信する】ボタンを押下したとき' do
+      it '入力した内容が保存されること' do
+        expect do
+          expect(find('#inquiry_submitted', visible: false).value).to eq nil
+          click_on '入力内容を確認'
+          click_on 'この内容で送信する'
+          expect(page).to have_content 'お問い合わせ内容を送信しました'
+        end.to change(Inquiry, :count).by(1)
+      end
+    end
+  end
+  # pending "add some scenarios (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
close #207
  
## 実装内容
- Inquiryモデルでインクルードしている、バリデーションのモジュールを修正
  - `if 修飾子`を使用して条件を設定
  - `:submitted`のバリデーションエラーメッセージが表示されないように設定
### テスト内容
#### お問い合わせ機能
- 入力内容が条件を満たすとき、確認画面に遷移し入力した内容が表示されていること
- 【入力画面に戻る】ボタンを押下した時、入力画面に遷移し入力した内容が表示されていること
- 【この内容で送信する】ボタンを押下した時、入力した内容が保存されること
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec/system/inquiries_spec.rb`を実行して期待した通り動作することを確認