### PR TITLE
アイテム追加ボタンを修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,7 +9,6 @@ class ItemsController < ApplicationController
   end
 
   def create
-    registered_item? and return
     @item = current_user.items.build(item_params)
     if @item.save
       redirect_to user_items_path, notice: "#{@item.name} をマイアイテムに追加しました"
@@ -31,11 +30,5 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:name, :genre, :remote_image_url)
-  end
-
-  def registered_item?
-    return unless current_user.items.find_by(name: item_params[:name])
-
-    redirect_to user_items_path, alert: "#{item_params[:name]} は既に登録されています"
   end
 end

--- a/app/controllers/search_items_controller.rb
+++ b/app/controllers/search_items_controller.rb
@@ -1,7 +1,6 @@
 class SearchItemsController < ApplicationController
   def index
-    return unless params[:keyword]
-
+    flash.now[:alert] = 'キーワードを入力して下さい' if params[:keyword].blank?
     @search_items = RakutenWebService::Ichiba::Product.search(keyword: params[:keyword])
   end
 end

--- a/app/helpers/search_items_helper.rb
+++ b/app/helpers/search_items_helper.rb
@@ -1,2 +1,5 @@
 module SearchItemsHelper
+  def registered_item?(item_name)
+    current_user.items.any? { |item| item.name == item_name }
+  end
 end

--- a/app/views/search_items/_search_item.html.erb
+++ b/app/views/search_items/_search_item.html.erb
@@ -12,7 +12,7 @@
           <p class="text-muted px-2"><%= item["genreName"] %></p>
         <% end %>
         <% if registered_item?(item["productName"]) %>
-          <%= link_to "登録済み", user_items_path(current_user), type: "button", class: "btn btn-dark-gray mt-auto mx-lg-2 disabled" %>
+          <%= button_tag "登録済み", disabled: true, class: "btn btn-dark-gray mx-lg-2" %>
         <% else %>
           <%= link_to "追加", user_items_path(current_user, item: {name: item["productName"], genre: item["genreName"], remote_image_url: item["mediumImageUrl"]}), method: :post, type: "button", class: "btn btn-outline-main mx-lg-2", data: { disable_with: "追加..."} %>
         <% end %>

--- a/app/views/search_items/_search_item.html.erb
+++ b/app/views/search_items/_search_item.html.erb
@@ -1,4 +1,4 @@
-<% if search_items.count > 0 %>
+<% if params[:keyword].present? && search_items.count > 0 %>
   <ul class="row bg-white py-3 px-0 mb-0">
     <% search_items.each do |item| %>
       <li class="col-6 col-sm-4 col-lg-2 d-flex flex-column px-lg-1 pt-2 mb-3">

--- a/app/views/search_items/_search_item.html.erb
+++ b/app/views/search_items/_search_item.html.erb
@@ -1,22 +1,22 @@
 <% if search_items.count > 0 %>
   <ul class="row bg-white py-3 px-0 mb-0">
     <% search_items.each do |item| %>
-      <%= link_to item["affiliateUrl"], class: "text-reset", target: "_blank" do %>
-        <li class="col-6 col-sm-4 col-lg-2 d-flex flex-column px-lg-1 pt-2 mb-3">
-          <div class="d-flex justify-content-center">
+      <li class="col-6 col-sm-4 col-lg-2 d-flex flex-column px-lg-1 pt-2 mb-3">
+        <%= link_to item["affiliateUrl"], class: "text-reset mb-auto", target: "_blank" do %>
+          <div class="d-flex justify-content-center mb-2">
             <div class="d-flex justify-content-center align-items-center bg-white search-item-image">
               <%= image_tag item["mediumImageUrl"], class: "img-fluid" %>
             </div>
           </div>
-          <h6 class="px-2 py-2"><%= item["productName"] %></h6>
+          <h6 class="px-2"><%= item["productName"] %></h6>
           <p class="text-muted px-2"><%= item["genreName"] %></p>
-          <% if registered_item?(item["productName"]) %>
-            <%= link_to "登録済み", user_items_path(current_user), type: "button", class: "btn btn-dark-gray mt-auto mx-lg-2 disabled" %>
-          <% else %>
-            <%= link_to "追加", user_items_path(current_user, item: {name: item["productName"], genre: item["genreName"], remote_image_url: item["mediumImageUrl"]}), method: :post, type: "button", class: "btn btn-outline-main mt-auto mx-lg-2", data: { disable_with: "追加..."} %>
-          <% end %>
-        </li>
-      <% end %>
+        <% end %>
+        <% if registered_item?(item["productName"]) %>
+          <%= link_to "登録済み", user_items_path(current_user), type: "button", class: "btn btn-dark-gray mt-auto mx-lg-2 disabled" %>
+        <% else %>
+          <%= link_to "追加", user_items_path(current_user, item: {name: item["productName"], genre: item["genreName"], remote_image_url: item["mediumImageUrl"]}), method: :post, type: "button", class: "btn btn-outline-main mx-lg-2", data: { disable_with: "追加..."} %>
+        <% end %>
+      </li>
     <% end %>
   </ul>
 <% else %>

--- a/app/views/search_items/_search_item.html.erb
+++ b/app/views/search_items/_search_item.html.erb
@@ -10,7 +10,11 @@
           </div>
           <h6 class="px-2 py-2"><%= item["productName"] %></h6>
           <p class="text-muted px-2"><%= item["genreName"] %></p>
-          <%= link_to "追加", user_items_path(current_user, item: {name: item["productName"], genre: item["genreName"], remote_image_url: item["mediumImageUrl"]}), method: :post, type: "button", class: "btn btn-outline-main mt-auto mx-lg-2" %>
+          <% if registered_item?(item["productName"]) %>
+            <%= link_to "登録済み", user_items_path(current_user), type: "button", class: "btn btn-dark-gray mt-auto mx-lg-2 disabled" %>
+          <% else %>
+            <%= link_to "追加", user_items_path(current_user, item: {name: item["productName"], genre: item["genreName"], remote_image_url: item["mediumImageUrl"]}), method: :post, type: "button", class: "btn btn-outline-main mt-auto mx-lg-2", data: { disable_with: "追加..."} %>
+          <% end %>
         </li>
       <% end %>
     <% end %>

--- a/app/views/search_items/index.js.erb
+++ b/app/views/search_items/index.js.erb
@@ -1,1 +1,2 @@
 document.getElementById('search-item-list').innerHTML = '<%= j render("search_item", search_items: @search_items) %>'
+document.getElementById('flash-messages').innerHTML = '<%= j render("layouts/flash_messages") %>';

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe 'アイテム機能', type: :system do
   end
 
   describe 'アイテム追加機能' do
+    let(:user) { create(:user) }
     context '検索したアイテムの追加ボタンを押下したとき' do
-      let(:user) { create(:user) }
       let(:item) { build(:item, user: user) }
       it 'そのアイテムがマイアイテムに追加されること' do
         visit user_items_path(user)
@@ -23,23 +23,52 @@ RSpec.describe 'アイテム機能', type: :system do
         expect do
           within '.search-item-group' do
             click_on 'アイテムを追加する'
-            fill_in 'keyword', with: 'テストアイテム'
+            fill_in 'keyword', with: item.name
             find('.input-group-append button').click
           end
           within '#search-item-list' do
-            all('li')[0].click_on '追加'
+            expect(first('li')).to have_selector "img[src='#{item.remote_image_url}']"
+            expect(first('li')).to have_content item.name
+            expect(first('li')).to have_content item.genre
+            first('li').click_on '追加'
           end
-          expect(page).to have_content "#{user.items.first.name} をマイアイテムに追加しました"
-          expect(page).to have_selector "img[src='#{user.items.first.image.url}']"
-          expect(page).to have_content user.items.first.name
-          expect(page).to have_content user.items.first.genre
+          expect(page).to have_content "#{item.name} をマイアイテムに追加しました"
+          within "#my-item-#{user.items.last.id}" do
+            expect(page).to have_selector "img[src='#{user.items.last.image.url}']"
+            expect(page).to have_content item.name
+            expect(page).to have_content item.genre
+          end
         end.to change { user.items.count }.by(1)
       end
     end
 
-    context '追加ボタンを押下したアイテムが既に登録済みのとき' do
-      let(:user) { create(:user) }
+    context 'アイテムが既に登録済みのとき' do
       let(:item) { create(:item, image: nil, user: user) }
+      it 'ボタンが【登録済み】と表示されること' do
+        visit user_items_path(user)
+        product = [{ 'affiliateUrl' => Faker::Internet.url, 'mediumImageUrl' => item.remote_image_url, 'productName' => item.name, 'genreName' => item.genre }]
+        search_items_mock = class_double(RakutenWebService::Ichiba::Product)
+        allow(search_items_mock).to receive(:search)
+        allow(RakutenWebService::Ichiba::Product).to receive(:search).and_return(product)
+        expect { search_items_mock.search }.not_to raise_error
+        expect do
+          within '.search-item-group' do
+            click_on 'アイテムを追加する'
+            fill_in 'keyword', with: item.name
+            find('.input-group-append button').click
+          end
+          within '#search-item-list' do
+            expect(first('li')).to have_selector "img[src='#{item.remote_image_url}']"
+            expect(first('li')).to have_content item.name
+            expect(first('li')).to have_content item.genre
+            expect(first('li')).to have_button '登録済み', disabled: true
+          end
+        end.to change { user.items.count }.by(0)
+      end
+    end
+
+    context 'アイテム追加の条件を満たさないとき' do
+      let(:item) { build(:item, name: nil, user: user) }
       it 'エラーが発生すること' do
         visit user_items_path(user)
         product = [{ 'affiliateUrl' => Faker::Internet.url, 'mediumImageUrl' => item.remote_image_url, 'productName' => item.name, 'genreName' => item.genre }]
@@ -54,34 +83,7 @@ RSpec.describe 'アイテム機能', type: :system do
             find('.input-group-append button').click
           end
           within '#search-item-list' do
-            all('li')[0].click_on '追加'
-          end
-          expect(page).to have_content "#{user.items.first.name} は既に登録されています"
-          expect(page).to have_selector "img[src='#{user.items.first.image.url}']"
-          expect(page).to have_content user.items.first.name
-          expect(page).to have_content user.items.first.genre
-        end.to change { user.items.count }.by(0)
-      end
-    end
-
-    context 'アイテム追加の条件を満たさないとき' do
-      let(:user) { create(:user) }
-      let(:item) { build(:item, name: nil, user: user) }
-      it 'エラーが発生すること' do
-        visit user_items_path(user)
-        product = [{ 'affiliateUrl' => Faker::Internet.url, 'mediumImageUrl' => item.remote_image_url, 'productName' => '', 'genreName' => item.genre }]
-        search_items_mock = class_double(RakutenWebService::Ichiba::Product)
-        allow(search_items_mock).to receive(:search)
-        allow(RakutenWebService::Ichiba::Product).to receive(:search).and_return(product)
-        expect { search_items_mock.search }.not_to raise_error
-        expect do
-          within '.search-item-group' do
-            click_on 'アイテムを追加する'
-            fill_in 'keyword', with: 'テストアイテム'
-            find('.input-group-append button').click
-          end
-          within '#search-item-list' do
-            all('li')[0].click_on '追加'
+            first('li').click_on '追加'
           end
           expect(page).to have_content 'アイテムを追加することができませんでした'
         end.to change { user.items.count }.by(0)

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -89,6 +89,13 @@ RSpec.describe 'アイテム機能', type: :system do
         end.to change { user.items.count }.by(0)
       end
     end
+
+    context 'キーワードを入力せずに直接アイテム検索ページへアクセスした場合' do
+      it 'フラッシュメッセージが表示されること' do
+        visit search_items_path
+        expect(page).to have_content 'キーワードを入力して下さい'
+      end
+    end
   end
 
   describe 'アイテム削除機能' do


### PR DESCRIPTION
close #209
  
## 実装内容
- アイテム追加ボタンに`:disable_with`を追加して、二重クリックを防止
- 検索した各アイテムのレイアウトで`Rows`直下に`Columns`が配置されるように、`link_to do end`ブロック間の範囲を修正
- ページ遷移機能が必要ないため、「登録済み」のアイテムのボタンの表示を link_to から`button_tag`に修正
  
### テスト内容の修正
- アイテム追加機能のシステムスペックでユーザーの作成を`let`で共通化
- 表示されているか検証する文字列を修正
- クリックするボタンの指定方法を修正
- キーワードを入力せずに直接アイテム検索ページへアクセスした場合のテストを追加
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec/forms spec/models spec/system spec/mailers`を実行してテストが期待通り通過することを検証