### PR TITLE
ユーザーページのプロフィール欄を修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -92,7 +92,6 @@ button.close, button.navbar-toggler {
 .avatar-container {
   position: relative;
   max-width: 200px;
-  height: 100%;
   .avatar-label {
     position: absolute;
     top: 0;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -53,6 +53,10 @@ footer {
   }
 }
 
+ul {
+  list-style: none;
+}
+
 @media (max-width: 575.98px) {
   .footer-before-signing {
     margin-bottom: -54px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -88,6 +88,7 @@ button.close, button.navbar-toggler {
 .avatar-container {
   position: relative;
   max-width: 200px;
+  height: 100%;
   .avatar-label {
     position: absolute;
     top: 0;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -91,12 +91,12 @@ button.close, button.navbar-toggler {
 
 .avatar-container {
   position: relative;
-  max-width: 200px;
+  max-width: 160px;
   .avatar-label {
     position: absolute;
     top: 0;
-    height: 200px;
-    width: 200px;
+    height: 100%;
+    width: 100%;
     background-image: url("/images/fallback/default.png");
     background-position: center;
     background-repeat: no-repeat;

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -3,11 +3,12 @@
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
 .user-name {
-  font-size: 24px;
+  font-size: 20px;
 }
 
 .user-info {
-  font-size: 18px;
+  font-size: 12px;
+  align-items: center;
 }
 
 #list-tab {
@@ -52,4 +53,13 @@
   content: "";
   display: block;
   padding-top: 100%;
+}
+
+@media (min-width: 576px) {
+  .user-name {
+    font-size: 24px;
+  }
+  .user-info {
+    font-size: 16px;
+  }
 }

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -2,6 +2,8 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
+@import 'valiables';
+
 .user-name {
   font-size: 20px;
 }
@@ -16,6 +18,7 @@
     border: 0;
     background-color: transparent;
     opacity: 0.5;
+    border-bottom: 2px solid $dark-gray;
     &:hover {
       background-color: #dedcda;
       opacity: 1.0;
@@ -25,6 +28,9 @@
   border-bottom: 2px solid;
   background-color: transparent;
   opacity: 1.0;
+  }
+  .tab-font-size {
+    font-size: 12px;
   }
 }
 

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -29,8 +29,11 @@
   background-color: transparent;
   opacity: 1.0;
   }
-  .tab-font-size {
+  .tab-text {
     font-size: 12px;
+    font-weight: bold;
+    text-align: center;
+    margin-bottom: 0;
   }
 }
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -19,18 +19,18 @@
         <div class="user-info text-muted">
           <ul class="d-flex flex-wrap pl-0">
             <li class="pr-3 pr-sm-5">
-              <%= @user.household_i18n %>
+              <i class="fas fa-house-user mr-1"></i><%= @user.household_i18n %>
             </li>
             <li class="pr-3 pr-sm-5">
-              <%= @user.address_i18n %>
+              <i class="fas fa-map-marker-alt mr-1"></i><%= @user.address_i18n %>
             </li>
             <li class="pr-3 pr-sm-5">
-              <%= @user.age_i18n %>
+              <i class="fas fa-user-clock mr-1"></i><%= @user.age_i18n %>
             </li>
           </ul>
           <% if @user.favorite_items? %>
             <p class="mb-3">
-              <%= @user.favorite_items %>
+              <i class="far fa-star mr-2"></i><%= @user.favorite_items %>
             </p>
           <% end %>
         </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -63,23 +63,23 @@
   <div class="col-12 col-xl-6 d-flex flex-column h-100">
     <div class="list-group list-group-horizontal w-100" id="list-tab" role="tablist">
       <a class="list-group-item flex-fill list-group-item-action active text-reset rounded-0 px-0" id="list-posts-list" data-toggle="list" href="#list-posts" role="tab" aria-controls="posts" data-tab="list-posts">
-        <small class="d-flex justify-content-center">
+        <p class="tab-font-size text-center font-weight-bold mb-0">
           <i class="far fa-folder-open align-self-center mr-1"></i>投稿
-        </small>
+        </p>
       </a>
       <a class="list-group-item flex-fill list-group-item-action text-reset rounded-0 px-0" id="list-liked-list" data-toggle="list" href="#list-liked" role="tab" aria-controls="liked" data-tab="list-liked">
-        <small class="d-flex justify-content-center">
+        <p class="tab-font-size text-center font-weight-bold mb-0">
           <i class="far fa-heart align-self-center mr-1"></i>いいね一覧
-        </small>
+        </p>
       </a>
       <a class="list-group-item flex-fill list-group-item-action text-reset rounded-0 px-0" id="list-<%= tab_name(@user) %>-list" data-toggle="list" href="#list-<%= tab_name(@user) %>" role="tab" aria-controls="<%= tab_name(@user) %>" data-tab="list-<%= tab_name(@user) %>">
-        <small class="d-flex justify-content-center">
+        <p class="tab-font-size text-center font-weight-bold mb-0">
           <% if current_user.id == @user.id %>
             <i class="far fa-bookmark align-self-center mr-1"></i>マーク一覧
           <% elsif %>
             <i class="fas fa-couch align-self-center mr-1"></i>アイテム
           <% end %>
-        </small>
+        </p>
       </a>
     </div>
     <div class="tab-content pt-3 pb-sm-5" id="nav-tabContent">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,23 +15,6 @@
           <div class="font-weight-bold user-name mb-3">
             <%= @user.name %>
           </div>
-          <% if current_user.id == @user.id %>
-            <div class="dropdown ml-auto ml-sm-0 ml-xl-auto">
-              <button class="btn btn-link text-reset" type="button" id="user-menu-list" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <i class="fas fa-list-ul fa-lg"></i>
-              </button>
-              <div class="dropdown-menu dropdown-menu-right text-center" aria-labelledby="user-menu-list">
-                <%= link_to edit_user_registration_path, class: "dropdown-item text-left" do %>
-                  <i class="fas fa-cog"></i>
-                  <span class="pl-2">プロフィール編集</span>
-                <% end %>
-                <%= link_to user_items_path(current_user), class: "dropdown-item text-left" do %>
-                  <i class="fas fa-couch"></i>
-                  <span class="pl-2">マイアイテム</span>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
         </div>
         <div class="user-info text-muted">
           <ul class="d-flex flex-wrap pl-0">
@@ -51,6 +34,19 @@
             </p>
           <% end %>
         </div>
+        <% if current_user.id == @user.id %>
+          <div class="d-flex flex-column flex-sm-row">
+            <%= link_to edit_user_registration_path, class: "btn btn-sm bg-light border font-weight-bold mb-2" do %>
+              <i class="fas fa-cog"></i>
+              <span class="pl-2">プロフィール編集</span>
+            <% end %>
+            <span class="mx-sm-3"></span>
+            <%= link_to user_items_path(current_user), class: "btn btn-sm bg-light border font-weight-bold mb-2" do %>
+              <i class="fas fa-couch"></i>
+              <span class="pl-2">マイアイテム</span>
+            <% end %>
+          </div>
+        <% end %>
       </div>
     </div>
     <div class="col-12 d-block px-0 mb-3">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,56 +6,59 @@
 </div>
 <div class="row">
   <div class="col-12 col-xl-6 d-flex flex-column h-100">
-    <div class="row no-gutters mb-3">
-      <div class="col-3 col-md-4 avatar-container mr-3 mr-md-5">
-        <%= image_tag @user.avatar.url, class: "rounded-circle user-avatar bg-light" %>
-      </div>
-      <div class="col d-flex flex-column">
-        <div class="d-flex">
-          <div class="font-weight-bold user-name mb-3">
-            <%= @user.name %>
+    <div class="d-flex flex-column mb-4">
+      <div class="row no-gutters mb-3 mb-sm-0">
+        <div class="col-3 mr-3">
+          <div class="avatar-container mx-auto">
+            <%= image_tag @user.avatar.url, class: "rounded-circle user-avatar bg-light" %>
           </div>
         </div>
-        <div class="user-info text-muted">
-          <ul class="d-flex flex-wrap pl-0">
-            <li class="pr-3 pr-sm-5">
-              <i class="fas fa-house-user mr-1"></i><%= @user.household_i18n %>
-            </li>
-            <li class="pr-3 pr-sm-5">
-              <i class="fas fa-map-marker-alt mr-1"></i><%= @user.address_i18n %>
-            </li>
-            <li class="pr-3 pr-sm-5">
-              <i class="fas fa-user-clock mr-1"></i><%= @user.age_i18n %>
-            </li>
-          </ul>
-          <% if @user.favorite_items? %>
-            <p class="mb-3">
-              <i class="far fa-star mr-2"></i><%= @user.favorite_items %>
-            </p>
-          <% end %>
+        <div class="col d-flex flex-column">
+          <div class="d-flex">
+            <div class="font-weight-bold user-name mb-3">
+              <%= @user.name %>
+            </div>
+          </div>
+          <div class="user-info text-muted">
+            <ul class="d-flex flex-wrap pl-0">
+              <li class="pr-3 pr-sm-5">
+                <i class="fas fa-house-user mr-1"></i><%= @user.household_i18n %>
+              </li>
+              <li class="pr-3 pr-sm-5">
+                <i class="fas fa-map-marker-alt mr-1"></i><%= @user.address_i18n %>
+              </li>
+              <li class="pr-3 pr-sm-5">
+                <i class="fas fa-user-clock mr-1"></i><%= @user.age_i18n %>
+              </li>
+            </ul>
+            <% if @user.favorite_items? %>
+              <p class="mb-3">
+                <i class="far fa-star mr-2"></i><%= @user.favorite_items %>
+              </p>
+            <% end %>
+          </div>
         </div>
-        <% if current_user.id == @user.id %>
-          <div class="d-flex flex-column flex-sm-row">
-            <%= link_to edit_user_registration_path, class: "btn btn-sm bg-light border font-weight-bold mb-2" do %>
+      </div>
+      <% if current_user.id == @user.id %>
+        <div class="row no-gutters justify-content-start pl-sm-3 mb-4">
+          <div class="col-12 offset-sm-3 col-sm-9 d-flex d-sm-block">
+            <%= link_to edit_user_registration_path, class: "flex-fill btn btn-sm bg-light border font-weight-bold" do %>
               <i class="fas fa-cog"></i>
               <span class="pl-2">プロフィール編集</span>
             <% end %>
-            <span class="mx-sm-3"></span>
-            <%= link_to user_items_path(current_user), class: "btn btn-sm bg-light border font-weight-bold mb-2" do %>
+            <%= link_to user_items_path(current_user), class: "flex-fill btn btn-sm bg-light border font-weight-bold" do %>
               <i class="fas fa-couch"></i>
               <span class="pl-2">マイアイテム</span>
             <% end %>
           </div>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
+      <% if @user.profile? %>
+        <p class="text-justify">
+          <%= @user.profile %>
+        </p>
+      <% end %>
     </div>
-    <div class="col-12 d-block px-0 mb-3">
-        <% if @user.profile? %>
-          <p class="mb-3">
-            <%= @user.profile %>
-          </p>
-        <% end %>
-      </div>
   </div>
   <div class="col-12 col-xl-6 d-flex flex-column h-100">
     <div class="list-group list-group-horizontal w-100" id="list-tab" role="tablist">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -63,17 +63,17 @@
   <div class="col-12 col-xl-6 d-flex flex-column h-100">
     <div class="list-group list-group-horizontal w-100" id="list-tab" role="tablist">
       <a class="list-group-item flex-fill list-group-item-action active text-reset rounded-0 px-0" id="list-posts-list" data-toggle="list" href="#list-posts" role="tab" aria-controls="posts" data-tab="list-posts">
-        <p class="tab-font-size text-center font-weight-bold mb-0">
+        <p class="tab-text">
           <i class="far fa-folder-open align-self-center mr-1"></i>投稿
         </p>
       </a>
       <a class="list-group-item flex-fill list-group-item-action text-reset rounded-0 px-0" id="list-liked-list" data-toggle="list" href="#list-liked" role="tab" aria-controls="liked" data-tab="list-liked">
-        <p class="tab-font-size text-center font-weight-bold mb-0">
+        <p class="tab-text">
           <i class="far fa-heart align-self-center mr-1"></i>いいね一覧
         </p>
       </a>
       <a class="list-group-item flex-fill list-group-item-action text-reset rounded-0 px-0" id="list-<%= tab_name(@user) %>-list" data-toggle="list" href="#list-<%= tab_name(@user) %>" role="tab" aria-controls="<%= tab_name(@user) %>" data-tab="list-<%= tab_name(@user) %>">
-        <p class="tab-font-size text-center font-weight-bold mb-0">
+        <p class="tab-text">
           <% if current_user.id == @user.id %>
             <i class="far fa-bookmark align-self-center mr-1"></i>マーク一覧
           <% elsif %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,44 +6,60 @@
 </div>
 <div class="row">
   <div class="col-12 col-xl-6 d-flex flex-column h-100">
-    <div class="row m-0">
-      <div class="col-3 col-md-4 avatar-container p-0 mb-4">
+    <div class="row no-gutters mb-3">
+      <div class="col-3 col-md-4 avatar-container mr-3 mr-md-5">
         <%= image_tag @user.avatar.url, class: "rounded-circle user-avatar bg-light" %>
       </div>
-      <% if current_user.id == @user.id %>
-        <div class="dropdown pl-3 ml-auto mt-auto">
-          <button class="btn btn-link text-reset" type="button" id="user-menu-list" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <i class="fas fa-list-ul fa-lg"></i>
-          </button>
-          <div class="dropdown-menu dropdown-menu-right text-center" aria-labelledby="user-menu-list">
-            <%= link_to edit_user_registration_path, class: "dropdown-item text-left" do %>
-              <i class="fas fa-cog"></i>
-              <span class="pl-2">プロフィール編集</span>
-            <% end %>
-            <%= link_to user_items_path(current_user), class: "dropdown-item text-left" do %>
-              <i class="fas fa-couch"></i>
-              <span class="pl-2">マイアイテム</span>
-            <% end %>
+      <div class="col d-flex flex-column">
+        <div class="d-flex">
+          <div class="font-weight-bold user-name mb-3">
+            <%= @user.name %>
           </div>
+          <% if current_user.id == @user.id %>
+            <div class="dropdown ml-auto ml-sm-0 ml-xl-auto">
+              <button class="btn btn-link text-reset" type="button" id="user-menu-list" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <i class="fas fa-list-ul fa-lg"></i>
+              </button>
+              <div class="dropdown-menu dropdown-menu-right text-center" aria-labelledby="user-menu-list">
+                <%= link_to edit_user_registration_path, class: "dropdown-item text-left" do %>
+                  <i class="fas fa-cog"></i>
+                  <span class="pl-2">プロフィール編集</span>
+                <% end %>
+                <%= link_to user_items_path(current_user), class: "dropdown-item text-left" do %>
+                  <i class="fas fa-couch"></i>
+                  <span class="pl-2">マイアイテム</span>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
         </div>
-      <% end %>
-    </div>
-    <div class="d-flex font-weight-bold border-bottom user-name mb-3">
-      <%= @user.name %>
-    </div>
-    <div class="border-bottom user-info mb-3">
-      <%= @user.address_i18n %>
-    </div>
-    <% if @user.favorite_items? %>
-      <div class="border-bottom user-info mb-3">
-        <%= @user.favorite_items %>
+        <div class="user-info text-muted">
+          <ul class="d-flex flex-wrap pl-0">
+            <li class="pr-3 pr-sm-5">
+              <%= @user.household_i18n %>
+            </li>
+            <li class="pr-3 pr-sm-5">
+              <%= @user.address_i18n %>
+            </li>
+            <li class="pr-3 pr-sm-5">
+              <%= @user.age_i18n %>
+            </li>
+          </ul>
+          <% if @user.favorite_items? %>
+            <p class="mb-3">
+              <%= @user.favorite_items %>
+            </p>
+          <% end %>
+        </div>
       </div>
-    <% end %>
-    <% if @user.profile? %>
-      <div class="border-bottom user-info mb-3">
-        <%= @user.profile %>
+    </div>
+    <div class="col-12 d-block px-0 mb-3">
+        <% if @user.profile? %>
+          <p class="mb-3">
+            <%= @user.profile %>
+          </p>
+        <% end %>
       </div>
-    <% end %>
   </div>
   <div class="col-12 col-xl-6 d-flex flex-column h-100">
     <div class="list-group list-group-horizontal w-100" id="list-tab" role="tablist">

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe 'ユーザー機能', type: :system do
         expect(page).to have_content user.address_i18n
         expect(page).to have_content user.favorite_items
         expect(page).to have_content user.profile
-        expect(page).to have_css '#user-menu-list'
+        expect(page).to have_link 'プロフィール編集'
+        expect(page).to have_link 'マイアイテム'
         user.post_with_photos.each do |post|
           expect(page).to have_selector "img[src='#{post.photos.first.image.url}']"
         end
@@ -56,7 +57,8 @@ RSpec.describe 'ユーザー機能', type: :system do
         expect(page).to have_content other_user.address_i18n
         expect(page).to have_content other_user.favorite_items
         expect(page).to have_content other_user.profile
-        expect(page).not_to have_css '#user-menu-list'
+        expect(page).not_to have_link 'プロフィール編集'
+        expect(page).not_to have_link 'マイアイテム'
         other_user.post_with_photos.each do |post|
           expect(page).to have_selector "img[src='#{post.photos.first.image.url}']"
         end


### PR DESCRIPTION
close #213
  
## 実装内容
- `Rows`直下に`Columns`が配置されるようにユーザーページ全体を修正
- `ulタグ`に`list-style:none;`を設定
- プロフィール画像の最大サイズを`160px`に修正
- プロフィール画像の右側に「ユーザー名」,「`年代」, 「家族構成」, 「お住まい」を表示
- 「ユーザー名」, 「年代」, 「家族構成」, 「お住まい」の左側にアイコンを追加
- 「プロフィール編集」, 「マイアイテム」へのリンクをドロップダウンメニューでは無く、ボタンとして常時表示
- 「ユーザー名」,「年代」, 「家族構成」, 「お住まい」のフォントサイズのブレイクポイントを`モバイルファースト`で設定
  - ユーザー名は`20px`として画面サイズが`sm 以上`の場合では`24px`に設定
  - ユーザー情報は`12px`として画面サイズが`sm 以上`の場合では`16px`に設定
- 投稿リストのタブの名称を修正
  - `small タグ`から`p タグ`に修正
  - `display`を`flex`から`block`に修正
  - `font-weight`を`bold`に設定
  - `text-align`を`center`に設定
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec`を実行してテストが通過することを確認