### PR TITLE
タイムラインページのアカウント画像をアスペクト比を維持したままトリミング

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -92,6 +92,7 @@ button.close, button.navbar-toggler {
 .avatar-container {
   position: relative;
   max-width: 160px;
+  min-width: 32px;
   .avatar-label {
     position: absolute;
     top: 0;

--- a/app/views/posts/_time_line.html.erb
+++ b/app/views/posts/_time_line.html.erb
@@ -10,14 +10,16 @@
         </div>
         <div class="col-md-6">
           <div class="card-body d-flex flex-column h-100 p-0">
-            <div class="card-name text-truncate p-3">
-              <%= link_to user_path(post.user_id), class: 'text-reset' do %>
-                <%= image_tag post.user_avatar.url, class: "rounded-circle", size: "32x32" %>
-                <span class="pl-2">
+            <%= link_to user_path(post.user_id), class: 'text-reset' do %>
+              <div class="d-flex p-3">
+                <div class="avatar-container mr-2">
+                  <%= image_tag post.user_avatar.url, class: "user-avatar rounded-circle", size: "32x32" %>
+                </div>
+                <div class="text-truncate">
                   <%= post.user_name %>
-                </span>
-              <% end %>
-            </div>
+                </div>
+              </div>
+            <% end %>
             <div class="d-flex border-top px-3 py-2">
               <div class="mr-4" id="post-<%= post.id %>-like">
                 <% if post.liked_by?(current_user) %>


### PR DESCRIPTION
close #215
  
## 実装内容
- タイムラインページのアカウント画像のアスペクト比が崩れてしまっていたため、css を追加してトリミング
  - アスペクト比が崩れてしまっていたのを修正するため、ユーザーページのアカウント画像にも使用している`.avatar-container`, `.user-avatar`を class属性 に追加
  - 親要素がflexコンテナでも表示できるように`.avatar-container`の css に`min-width`を追加

## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec`を実行してテストが通過することを確認