### PR TITLE
アプリ名を変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :development do
   gem 'letter_opener_web', '~> 2.0'
   gem 'listen', '~> 3.3'
   gem 'rack-mini-profiler', '~> 2.0'
+  gem 'rename'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,6 +300,10 @@ GEM
       ffi (~> 1.0)
     redcarpet (3.5.1)
     regexp_parser (2.1.1)
+    rename (1.0.8)
+      activesupport
+      rails (>= 3.0.0)
+      thor (>= 0.19.1)
     request_store (1.5.0)
       rack (>= 1.4)
     require_all (3.0.0)
@@ -445,6 +449,7 @@ DEPENDENCIES
   rakuten_web_service
   ransack
   redcarpet
+  rename
   rspec-rails
   rubocop-performance
   rubocop-rails

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,7 @@ require 'sprockets/railtie'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module Moknow
+module Roomake
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -7,4 +7,4 @@ test:
 production:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: moknow_production
+  channel_prefix: roomake_production

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,13 +23,13 @@ default: &default
 
 development:
   <<: *default
-  database: moknow_development
+  database: roomake_development
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user running Rails.
-  #username: moknow
+  #username: roomake
 
   # The password associated with the postgres role (username).
   #password:
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: moknow_test
+  database: roomake_test
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -81,6 +81,6 @@ test:
 #
 production:
   <<: *default
-  database: moknow_production
-  username: moknow
-  password: <%= ENV['MOKNOW_DATABASE_PASSWORD'] %>
+  database: roomake_production
+  username: roomake
+  password: <%= ENV['roomake_DATABASE_PASSWORD'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "moknow_production"
+  # config.active_job.queue_name_prefix = "roomake_production"
 
   config.action_mailer.perform_caching = false
 

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -4,7 +4,7 @@ ActiveAdmin.setup do |config|
   # Set the title that is displayed on the main layout
   # for each of the active admin pages.
   #
-  config.site_title = 'Moknow'
+  config.site_title = 'Roomake'
 
   # Set the link url for the title. For example, to take
   # users to your main site. Defaults to no link.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "moknow",
+  "name":"roomake",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",


### PR DESCRIPTION
close #221
  
## 実装内容
- `gem rename`をインストール
- `rails db:drop`を実行して`moknow`のデータベースを削除
- `rails g rename:into roomake`を実行してアプリ名を`moknow`から`roomake`に変更
- `rails db:create`を実行して新しいデータベースを作成
- `rails db:migrate`, `rails db:seed`を実行してデータを作成
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec`を実行してテストが通過することを確認
- [x] http://localhost:3000 へアクセスしてローカル環境で動作することを確認