### PR TITLE
投稿画像プレビュー時の画像ファイルサイズ・形式のバリデーションエラー(フロント側)処理を修正

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,6 +93,10 @@ RSpec/EmptyLineAfterFinalLet:
 RSpec/ExampleLength:
   Enabled: false
 
+# I18n とロケールファイル使用の強制を解除して、文字列を使えるように設定
+Rails/I18nLocaleTexts:
+  Enabled: false
+
 # 一貫した暗黙の期待スタイルが使われているかどうかのチェックを解除
 RSpec/ImplicitExpect:
   Enabled: false

--- a/app/javascript/packs/photos_preview.js
+++ b/app/javascript/packs/photos_preview.js
@@ -28,9 +28,11 @@ $(document).on('turbolinks:load', function () {
         if(maxFileSize < file.size){
           // 画像ファイルが 5MB より大きい場合の処理
           alert('画像ファイルは最大 5MB 以下にしてください');
+          fileField.files = dataBox.files
         } else if (!mimeType.includes(file.type)){
           // 画像ファイルが .jpeg, .jpg, .png 以外の場合の処理
           alert('画像ファイルは .jpg, .jpeg, .png のみアップロードできます');
+          fileField.files = dataBox.files
         } else {
           const fileReader = new FileReader();
           const lastFileId = dataBox.files.length === 0 ? 0 : $(dataBox.files).last()[0].id;

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -52,6 +52,6 @@ class AvatarUploader < CarrierWave::Uploader::Base
 
   # ファイルサイズのバリデーション
   def size_range
-    0..5.megabytes
+    0..(5.megabytes)
   end
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -52,6 +52,6 @@ class ImageUploader < CarrierWave::Uploader::Base
   # end
   # ファイルサイズのバリデーション
   def size_range
-    0..5.megabytes
+    0..(5.megabytes)
   end
 end

--- a/app/uploaders/item_uploader.rb
+++ b/app/uploaders/item_uploader.rb
@@ -49,6 +49,6 @@ class ItemUploader < CarrierWave::Uploader::Base
   # end
   # ファイルサイズのバリデーション
   def size_range
-    0..5.megabytes
+    0..(5.megabytes)
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     household { rand(1..6) }
     favorite_items { Faker::Lorem.word }
     profile { Faker::Lorem.sentence }
-    avatar { Rack::Test::UploadedFile.new(Rails.root.join('public/images/fallback/default.png')) }
+    avatar { Rack::Test::UploadedFile.new(Rails.public_path.join('images/fallback/default.png')) }
   end
 
   factory :guest_user, class: 'User' do

--- a/spec/forms/post_form_spec.rb
+++ b/spec/forms/post_form_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe PostForm, type: :model do
     context 'データが条件を満たすとき' do
       let(:post_form) { build(:post_form) }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
     context 'content が空のとき' do
       let(:post_form) { build(:post_form, content: '') }
       it 'エラーが発生すること' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(post_form.errors.messages[:content]).to include 'を入力してください'
       end
     end
@@ -28,7 +28,7 @@ RSpec.describe PostForm, type: :model do
     context 'content が 2001 文字以上のとき' do
       let(:post_form) { build(:post_form, content: 'a' * 2001) }
       it 'エラーが発生すること' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(post_form.errors.messages[:content]).to include 'は2000文字以内で入力してください'
       end
     end
@@ -36,7 +36,7 @@ RSpec.describe PostForm, type: :model do
     context 'tag_ids が空のとき' do
       let(:post_form) { build(:post_form, tag_ids: '') }
       it 'エラーが発生すること' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(post_form.errors.messages[:tag_ids]).to include 'を入力してください'
       end
     end
@@ -44,7 +44,7 @@ RSpec.describe PostForm, type: :model do
     context 'tag_ids が3つ以上のとき' do
       let(:post_form) { build(:post_form, tag_ids: [1, 2, 3]) }
       it 'エラーが発生すること' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(post_form.errors.messages[:tag_ids]).to include 'は最大2つまで選択できます'
       end
     end
@@ -52,7 +52,7 @@ RSpec.describe PostForm, type: :model do
     context 'tag_ids の値と同じ id のタグが存在しない場合' do
       let(:post_form) { build(:post_form, tag_ids: [4]) }
       it 'エラーが発生すること' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(post_form.errors.messages[:tag_ids]).to include 'は選択肢の中から選んで下さい'
       end
     end
@@ -60,7 +60,7 @@ RSpec.describe PostForm, type: :model do
     context 'categoryr_ids が空のとき' do
       let(:post_form) { build(:post_form, category_ids: '') }
       it 'エラーが発生すること' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(post_form.errors.messages[:category_ids]).to include 'を入力してください'
       end
     end
@@ -68,7 +68,7 @@ RSpec.describe PostForm, type: :model do
     context 'categoryr_ids が3つ以上のとき' do
       let(:post_form) { build(:post_form, category_ids: [1, 2, 3]) }
       it 'エラーが発生すること' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(post_form.errors.messages[:category_ids]).to include 'は最大2つまで選択できます'
       end
     end
@@ -76,7 +76,7 @@ RSpec.describe PostForm, type: :model do
     context 'categoryr_ids の値と同じ id のカテゴリが存在しない場合' do
       let(:post_form) { build(:post_form, category_ids: [4]) }
       it 'エラーが発生すること' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(post_form.errors.messages[:category_ids]).to include 'は選択肢の中から選んで下さい'
       end
     end
@@ -84,7 +84,7 @@ RSpec.describe PostForm, type: :model do
     context 'images が空のとき' do
       let(:post_form) { build(:post_form, images: '') }
       it 'エラーが発生する' do
-        expect(post_form.valid?(:create)).to eq false
+        expect(post_form.valid?(:create)).to be false
         expect(post_form.errors.messages[:images]).to include 'を選択してください'
       end
     end
@@ -97,7 +97,7 @@ RSpec.describe PostForm, type: :model do
 
       let(:post_form) { build(:post_form, images: @images) }
       it 'エラーが発生する' do
-        expect(post_form.valid?(:create)).to eq false
+        expect(post_form.valid?(:create)).to be false
         expect(post_form.errors.messages[:images]).to include 'は最大6枚まで選択できます'
       end
     end
@@ -119,7 +119,7 @@ RSpec.describe PostForm, type: :model do
       context 'データが条件を満たすとき' do
         let(:post_form) { build(:post_form, post: post) }
         it '更新できること' do
-          expect(subject).to eq true
+          expect(subject).to be true
         end
       end
     end
@@ -136,7 +136,7 @@ RSpec.describe PostForm, type: :model do
     context '画像ファイルサイズが 5MB より大きいのとき' do
       let(:post_form) { build(:post_form, images: [Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/rspec_size_test.jpg'))]) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(post_form.errors.full_messages).to include 'Imageファイルを5MBバイト以下のサイズにしてください'
       end
     end
@@ -144,7 +144,7 @@ RSpec.describe PostForm, type: :model do
     context '画像ファイルタイプが jpg, jpeg, png 以外のとき' do
       let(:post_form) { build(:post_form, images: [Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/rspec_extension_test.tiff'))]) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(post_form.errors.full_messages).to include 'Image"tiff"ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: jpg, jpeg, png'
       end
     end

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe AdminUser, type: :model do
     context 'データが条件を満たすとき' do
       let(:admin_user) { build(:admin_user) }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
     context 'email が空のとき' do
       let(:admin_user) { build(:admin_user, email: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(admin_user.errors.messages[:email]).to include 'を入力してください'
       end
     end
@@ -26,7 +26,7 @@ RSpec.describe AdminUser, type: :model do
 
       let(:admin_user) { build(:admin_user, email: 'admin@example.com') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(admin_user.errors.messages[:email]).to include 'はすでに存在します'
       end
     end
@@ -34,7 +34,7 @@ RSpec.describe AdminUser, type: :model do
     context 'email がアルファベット・英数字のみのとき' do
       let(:admin_user) { build(:admin_user, email: Faker::Lorem.characters(number: 16)) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(admin_user.errors.messages[:email]).to include 'は不正な値です'
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe AdminUser, type: :model do
     context 'password が空のとき' do
       let(:admin_user) { build(:admin_user, password: '') }
       it 'エラーが発生すること' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(admin_user.errors.messages[:password]).to include 'を入力してください'
       end
     end
@@ -50,7 +50,7 @@ RSpec.describe AdminUser, type: :model do
     context 'password が5文字以下のとき' do
       let(:admin_user) { build(:admin_user, password: 'a' * 5) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(admin_user.errors.messages[:password]).to include 'は6文字以上で入力してください'
       end
     end
@@ -58,7 +58,7 @@ RSpec.describe AdminUser, type: :model do
     context 'password が129文字以上のとき' do
       let(:admin_user) { build(:admin_user, password: 'a' * 129) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(admin_user.errors.messages[:password]).to include 'は128文字以内で入力してください'
       end
     end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Category, type: :model do
     context 'データが条件を満たすとき' do
       let(:category) { build(:category) }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
     context 'name が空のとき' do
       let(:category) { build(:category, name: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(category.errors.messages[:name]).to include 'を入力してください'
       end
     end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Comment, type: :model do
     context 'データが条件を満たすとき' do
       let(:comment) { build(:comment) }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
     context 'content が空のとき' do
       let(:comment) { build(:comment, content: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(comment.errors.messages[:content]).to include 'を入力してください'
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe Comment, type: :model do
     context 'content が141文字以上のとき' do
       let(:comment) { build(:comment, content: 'a' * 141) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(comment.errors.messages[:content]).to include 'は140文字以内で入力してください'
       end
     end
@@ -30,7 +30,7 @@ RSpec.describe Comment, type: :model do
     context 'user_id が空のとき' do
       let(:comment) { build(:comment, user_id: nil) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(comment.errors.messages[:user]).to include 'を入力してください'
       end
     end
@@ -38,7 +38,7 @@ RSpec.describe Comment, type: :model do
     context 'post_id が空のとき' do
       let(:comment) { build(:comment, post_id: nil) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(comment.errors.messages[:post]).to include 'を入力してください'
       end
     end

--- a/spec/models/inquiry_spec.rb
+++ b/spec/models/inquiry_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Inquiry, type: :model do
     context 'データが条件を満たすとき' do
       let(:inquiry) { build(:inquiry) }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
     context 'name が空の時' do
       let(:inquiry) { build(:inquiry, name: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(inquiry.errors.messages[:name]).to include 'を入力してください'
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe Inquiry, type: :model do
     context 'name が49文字以上のとき' do
       let(:inquiry) { build(:inquiry, name: 'a' * 49) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(inquiry.errors.messages[:name]).to include 'は48文字以内で入力してください'
       end
     end
@@ -30,7 +30,7 @@ RSpec.describe Inquiry, type: :model do
     context 'name_kana が空のとき' do
       let(:inquiry) { build(:inquiry, name_kana: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(inquiry.errors.messages[:name_kana]).to include 'を入力してください'
       end
     end
@@ -38,7 +38,7 @@ RSpec.describe Inquiry, type: :model do
     context 'name_kana が全角カタカナ以外のとき' do
       let(:inquiry) { build(:inquiry, name_kana: 'ﾌﾘｶﾞﾅ') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(inquiry.errors.messages[:name_kana]).to include 'は全角カタカナで入力してください'
       end
     end
@@ -46,7 +46,7 @@ RSpec.describe Inquiry, type: :model do
     context 'name_kana が49文字以上のとき' do
       let(:inquiry) { build(:inquiry, name_kana: 'a' * 49) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(inquiry.errors.messages[:name_kana]).to include 'は48文字以内で入力してください'
       end
     end
@@ -54,7 +54,7 @@ RSpec.describe Inquiry, type: :model do
     context 'email が空のとき' do
       let(:inquiry) { build(:inquiry, email: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(inquiry.errors.messages[:email]).to include 'を入力してください'
       end
     end
@@ -62,7 +62,7 @@ RSpec.describe Inquiry, type: :model do
     context 'email がアルファベット・英数字のみのとき' do
       let(:inquiry) { build(:inquiry, email: Faker::Lorem.characters(number: 16)) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(inquiry.errors.messages[:email]).to include 'は不正な値です'
       end
     end
@@ -70,7 +70,7 @@ RSpec.describe Inquiry, type: :model do
     context 'email が257文字以上のとき' do
       let(:inquiry) { build(:inquiry, email: Faker::Lorem.characters(number: 257)) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(inquiry.errors.messages[:email]).to include 'は256文字以内で入力してください'
       end
     end
@@ -78,7 +78,7 @@ RSpec.describe Inquiry, type: :model do
     context 'content が空のとき' do
       let(:inquiry) { build(:inquiry, content: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(inquiry.errors.messages[:content]).to include 'を入力してください'
       end
     end
@@ -86,7 +86,7 @@ RSpec.describe Inquiry, type: :model do
     context 'content が2001文字以上のとき' do
       let(:inquiry) { build(:inquiry, content: 'a' * 2001) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(inquiry.errors.messages[:content]).to include 'は2000文字以内で入力してください'
       end
     end
@@ -94,7 +94,7 @@ RSpec.describe Inquiry, type: :model do
     context 'remote_ip が空のとき' do
       let(:inquiry) { build(:inquiry, remote_ip: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(inquiry.errors.messages[:remote_ip]).to include 'を入力してください'
       end
     end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Item, type: :model do
     context 'データが条件を満たすとき' do
       let(:item) { build(:item) }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
     context 'name が空のとき' do
       let(:item) { build(:item, name: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(item.errors.messages[:name]).to include 'を入力してください'
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe Item, type: :model do
       end
 
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(item.errors.messages[:name]).to include 'は既に登録されています'
       end
     end
@@ -35,7 +35,7 @@ RSpec.describe Item, type: :model do
     context 'user_id が空のとき' do
       let(:item) { build(:item, user_id: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(item.errors.messages[:user]).to include 'を入力してください'
       end
     end

--- a/spec/models/know_how_spec.rb
+++ b/spec/models/know_how_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe KnowHow, type: :model do
     context 'データが条件を満たすとき' do
       let(:know_how) { build(:know_how) }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
     context 'genre が空のとき' do
       let(:know_how) { build(:know_how, genre: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(know_how.errors.messages[:genre]).to include 'を入力してください'
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe KnowHow, type: :model do
     context 'title が空のとき' do
       let(:know_how) { build(:know_how, title: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(know_how.errors.messages[:title]).to include 'を入力してください'
       end
     end
@@ -30,7 +30,7 @@ RSpec.describe KnowHow, type: :model do
     context 'content が空のとき' do
       let(:know_how) { build(:know_how, content: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(know_how.errors.messages[:content]).to include 'を入力してください'
       end
     end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Like, type: :model do
     context 'データが条件を満たすとき' do
       let(:like) { build(:like) }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
     context 'user_id が空のとき' do
       let(:like) { build(:like, user_id: nil) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(like.errors.messages[:user]).to include 'を入力してください'
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe Like, type: :model do
     context 'post_id が空のとき' do
       let(:like) { build(:like, post_id: nil) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(like.errors.messages[:post]).to include 'を入力してください'
       end
     end
@@ -36,7 +36,7 @@ RSpec.describe Like, type: :model do
       end
 
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(like.errors.messages[:user_id]).to include 'は同じ投稿に2回以上いいねはできません'
       end
     end

--- a/spec/models/mark_spec.rb
+++ b/spec/models/mark_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Mark, type: :model do
     context 'データが条件を満たすとき' do
       let(:mark) { build(:mark) }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
     context 'user_id が空のとき' do
       let(:mark) { build(:mark, user_id: nil) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(mark.errors.messages[:user]).to include 'を入力してください'
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe Mark, type: :model do
     context 'post_id が空のとき' do
       let(:mark) { build(:mark, post_id: nil) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(mark.errors.messages[:post]).to include 'を入力してください'
       end
     end
@@ -36,7 +36,7 @@ RSpec.describe Mark, type: :model do
       end
 
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(mark.errors.messages[:user_id]).to include 'は同じ投稿に2回以上マークはできません'
       end
     end

--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Photo, type: :model do
     context 'データが条件を満たすとき' do
       let(:photo) { build(:photo) }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
     context 'image の画像サイズが 5MB 以上のとき' do
       let(:photo) { build(:photo, image: Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/rspec_size_test.jpg'))) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(photo.errors.messages[:image]).to include 'ファイルを5MBバイト以下のサイズにしてください'
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe Photo, type: :model do
     context 'image の拡張子が .jpeg .jpg .png 以外のとき' do
       let(:photo) { build(:photo, image: Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/rspec_extension_test.tiff'))) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(photo.errors.messages[:image]).to include '"tiff"ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: jpg, jpeg, png'
       end
     end

--- a/spec/models/post_category_spec.rb
+++ b/spec/models/post_category_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe PostCategory, type: :model do
     context 'データが条件を満たすとき' do
       let(:post_category) { build(:post_category) }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
     context 'post_id が空のとき' do
       let(:post_category) { build(:post_category, post_id: nil) }
       it 'エラーが発生すること' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(post_category.errors.messages[:post]).to include 'を入力してください'
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe PostCategory, type: :model do
     context 'category_id が空のとき' do
       let(:post_category) { build(:post_category, category_id: nil) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(post_category.errors.messages[:category]).to include 'を入力してください'
       end
     end
@@ -36,7 +36,7 @@ RSpec.describe PostCategory, type: :model do
       end
 
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(post_category.errors.messages[:post_id]).to include 'ではすでにこのカテゴリが選択されています'
       end
     end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe Post, type: :model do
 
       context 'いいねした投稿の場合' do
         it 'true となること' do
-          expect(post1.liked_by?(user)).to eq true
+          expect(post1.liked_by?(user)).to be true
         end
       end
 
       context 'いいねした投稿では無い場合' do
         it 'false となること' do
-          expect(post2.liked_by?(user)).to eq false
+          expect(post2.liked_by?(user)).to be false
         end
       end
     end
@@ -32,13 +32,13 @@ RSpec.describe Post, type: :model do
 
       context 'マークした投稿の場合' do
         it 'true となること' do
-          expect(post1.marked_by?(user)).to eq true
+          expect(post1.marked_by?(user)).to be true
         end
       end
 
       context 'マークした投稿では無い場合' do
         it 'false となること' do
-          expect(post2.marked_by?(user)).to eq false
+          expect(post2.marked_by?(user)).to be false
         end
       end
     end

--- a/spec/models/post_tag_spec.rb
+++ b/spec/models/post_tag_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe PostTag, type: :model do
     context 'データが条件を満たすとき' do
       let(:post_tag) { build(:post_tag) }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
     context 'post_id が空のとき' do
       let(:post_tag) { build(:post_tag, post_id: nil) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(post_tag.errors.messages[:post]).to include 'を入力してください'
       end
     end
@@ -22,7 +22,7 @@ RSpec.describe PostTag, type: :model do
     context 'tag_id がからのとき' do
       let(:post_tag) { build(:post_tag, tag_id: nil) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(post_tag.errors.messages[:tag]).to include 'を入力してください'
       end
     end
@@ -36,7 +36,7 @@ RSpec.describe PostTag, type: :model do
       end
 
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(post_tag.errors.messages[:post_id]).to include 'ではすでにこのタグが選択されています'
       end
     end

--- a/spec/models/progress_spec.rb
+++ b/spec/models/progress_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Progress, type: :model do
     context 'データが条件を満たすとき' do
       let(:progress) { build(:progress) }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
     context 'user_id が空のとき' do
       let(:progress) { build(:progress, user_id: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(progress.errors.messages[:user]).to include 'を入力してください'
       end
     end
@@ -26,7 +26,7 @@ RSpec.describe Progress, type: :model do
     context 'know_how_id が空のとき' do
       let(:progress) { build(:progress, know_how_id: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(progress.errors.messages[:know_how]).to include 'を入力してください'
       end
     end
@@ -40,7 +40,7 @@ RSpec.describe Progress, type: :model do
       end
 
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(progress.errors.messages[:user_id]).to include 'は同じノウハウに2回以上チェックはできません'
       end
     end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Tag, type: :model do
     context 'データが条件を満たすとき' do
       let(:tag) { build(:tag) }
       it '保存されること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
     context 'name が空のとき' do
       let(:tag) { build(:tag, name: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(tag.errors.messages[:name]).to include 'を入力してください'
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe User, type: :model do
     context 'データが条件を満たすとき' do
       let(:user) { build(:user) }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
@@ -15,7 +15,7 @@ RSpec.describe User, type: :model do
     context 'name が空のとき' do
       let(:user) { build(:user, name: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(user.errors.messages[:name]).to include 'を入力してください'
       end
     end
@@ -23,7 +23,7 @@ RSpec.describe User, type: :model do
     context 'name が 31文字以上のとき' do
       let(:user) { build(:user, name: 'a' * 31) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(user.errors.messages[:name]).to include 'は30文字以内で入力してください'
       end
     end
@@ -32,7 +32,7 @@ RSpec.describe User, type: :model do
     context 'email が空のとき' do
       let(:user) { build(:user, email: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(user.errors.messages[:email]).to include 'を入力してください'
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe User, type: :model do
 
       let(:user) { build(:user, email: 'test@example.com') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(user.errors.messages[:email]).to include 'はすでに存在します'
       end
     end
@@ -50,7 +50,7 @@ RSpec.describe User, type: :model do
     context 'email がアルファベット･英数字 のみのとき' do
       let(:user) { build(:user, email: Faker::Lorem.characters(number: 16)) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(user.errors.messages[:email]).to include 'は不正な値です'
       end
     end
@@ -59,7 +59,7 @@ RSpec.describe User, type: :model do
     context 'password が空のとき' do
       let(:user) { build(:user, password: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(user.errors.messages[:password]).to include 'を入力してください'
       end
     end
@@ -67,7 +67,7 @@ RSpec.describe User, type: :model do
     context 'password が 5 文字以下のとき' do
       let(:user) { build(:user, password: 'a' * 5) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(user.errors.messages[:password]).to include 'は6文字以上で入力してください'
       end
     end
@@ -75,7 +75,7 @@ RSpec.describe User, type: :model do
     context 'password が 129 文字以上のとき' do
       let(:user) { build(:user, password: 'a' * 129) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(user.errors.messages[:password]).to include 'は128文字以内で入力してください'
       end
     end
@@ -84,7 +84,7 @@ RSpec.describe User, type: :model do
     context 'age が空のとき' do
       let(:user) { build(:user, age: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(user.errors.messages[:age]).to include 'を入力してください'
       end
     end
@@ -92,7 +92,7 @@ RSpec.describe User, type: :model do
     context 'age が文字列のとき' do
       let(:user) { build(:user, age: 'teens') }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
@@ -100,7 +100,7 @@ RSpec.describe User, type: :model do
     context 'address が空のとき' do
       let(:user) { build(:user, address: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(user.errors.messages[:address]).to include 'を入力してください'
       end
     end
@@ -108,7 +108,7 @@ RSpec.describe User, type: :model do
     context 'address が文字列のとき' do
       let(:user) { build(:user, address: 'hokkaido') }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
@@ -116,7 +116,7 @@ RSpec.describe User, type: :model do
     context 'household が空のとき' do
       let(:user) { build(:user, household: '') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(user.errors.messages[:household]).to include 'を入力してください'
       end
     end
@@ -124,7 +124,7 @@ RSpec.describe User, type: :model do
     context 'household が文字列のとき' do
       let(:user) { build(:user, household: 'single_household') }
       it '保存できること' do
-        expect(subject).to eq true
+        expect(subject).to be true
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe User, type: :model do
     context 'profile が 2001 文字以上のとき' do
       let(:user) { build(:user, profile: 'a' * 2001) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(user.errors.messages[:profile]).to include 'は2000文字以内で入力してください'
       end
     end
@@ -141,7 +141,7 @@ RSpec.describe User, type: :model do
     context 'avatar の画像サイズが 5MB 以上のとき' do
       let(:user) { build(:user, avatar: Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/rspec_size_test.jpg'))) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(user.errors.messages[:avatar]).to include 'ファイルを5MBバイト以下のサイズにしてください'
       end
     end
@@ -149,7 +149,7 @@ RSpec.describe User, type: :model do
     context 'avatar の拡張子が .jpeg .jpg .png 以外のとき' do
       let(:user) { build(:user, avatar: Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/rspec_extension_test.tiff'))) }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(user.errors.messages[:avatar]).to include '"tiff"ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: jpg, jpeg, png'
       end
     end
@@ -157,7 +157,7 @@ RSpec.describe User, type: :model do
     context '利用規約に同意していないとき' do
       let(:user) { build(:user, terms_of_use: '0') }
       it 'エラーが発生する' do
-        expect(subject).to eq false
+        expect(subject).to be false
         expect(user.errors.messages[:terms_of_use]).to include 'について同意してください'
       end
     end
@@ -273,7 +273,7 @@ RSpec.describe User, type: :model do
       context 'ゲストユーザーのデータがまだ存在しない場合' do
         let(:user) { build(:guest_user) }
         it '保存できること' do
-          expect(user.valid?).to eq true
+          expect(user.valid?).to be true
         end
       end
 

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'コメント機能', type: :system do
             find('#comment_content').set('')
             click_on '送信する'
           end
-        end.to change { post.comments.count }.by(0)
+        end.not_to(change { post.comments.count })
       end
     end
   end

--- a/spec/system/inquiries_spec.rb
+++ b/spec/system/inquiries_spec.rb
@@ -15,18 +15,18 @@ RSpec.describe 'お問い合わせ機能', type: :system do
     context '入力内容が条件を満たすとき' do
       it '確認画面に遷移し、入力した内容が表示されていること' do
         expect do
-          expect(find('#inquiry_submitted', visible: false).value).to eq nil
+          expect(find('#inquiry_submitted', visible: false).value).to be_nil
           click_on '入力内容を確認'
           expect(find('#inquiry_submitted', visible: false).value).to eq '1'
-          expect(find_field('お客様のお名前').readonly?).to eq true
+          expect(find_field('お客様のお名前').readonly?).to be true
           expect(find_field('お客様のお名前').value).to eq inquiry.name
-          expect(find_field('お客様のお名前(カナ)').readonly?).to eq true
+          expect(find_field('お客様のお名前(カナ)').readonly?).to be true
           expect(find_field('お客様のお名前(カナ)').value).to eq inquiry.name_kana
-          expect(find_field('メールアドレス').readonly?).to eq true
+          expect(find_field('メールアドレス').readonly?).to be true
           expect(find_field('メールアドレス').value).to eq inquiry.email
-          expect(find_field('お問い合わせ内容').readonly?).to eq true
+          expect(find_field('お問い合わせ内容').readonly?).to be true
           expect(find_field('お問い合わせ内容').value).to eq inquiry.content
-        end.to change(Inquiry, :count).by(0)
+        end.not_to change(Inquiry, :count)
       end
     end
   end
@@ -35,26 +35,26 @@ RSpec.describe 'お問い合わせ機能', type: :system do
     context '【入力画面に戻る】ボタンを押下したとき' do
       it '入力画面に遷移し、入力した内容が表示されていること' do
         expect do
-          expect(find('#inquiry_submitted', visible: false).value).to eq nil
+          expect(find('#inquiry_submitted', visible: false).value).to be_nil
           click_on '入力内容を確認'
           click_on '入力画面に戻る'
           expect(find('#inquiry_submitted', visible: false).value).to eq ''
-          expect(find_field('お客様のお名前').readonly?).to eq false
+          expect(find_field('お客様のお名前').readonly?).to be false
           expect(find_field('お客様のお名前').value).to eq inquiry.name
-          expect(find_field('お客様のお名前(カナ)').readonly?).to eq false
+          expect(find_field('お客様のお名前(カナ)').readonly?).to be false
           expect(find_field('お客様のお名前(カナ)').value).to eq inquiry.name_kana
-          expect(find_field('メールアドレス').readonly?).to eq false
+          expect(find_field('メールアドレス').readonly?).to be false
           expect(find_field('メールアドレス').value).to eq inquiry.email
-          expect(find_field('お問い合わせ内容').readonly?).to eq false
+          expect(find_field('お問い合わせ内容').readonly?).to be false
           expect(find_field('お問い合わせ内容').value).to eq inquiry.content
-        end.to change(Inquiry, :count).by(0)
+        end.not_to change(Inquiry, :count)
       end
     end
 
     context '【この内容で送信する】ボタンを押下したとき' do
       it '入力した内容が保存されること' do
         expect do
-          expect(find('#inquiry_submitted', visible: false).value).to eq nil
+          expect(find('#inquiry_submitted', visible: false).value).to be_nil
           click_on '入力内容を確認'
           click_on 'この内容で送信する'
           expect(page).to have_content 'お問い合わせ内容を送信しました'
@@ -62,5 +62,4 @@ RSpec.describe 'お問い合わせ機能', type: :system do
       end
     end
   end
-  # pending "add some scenarios (or delete) #{__FILE__}"
 end

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'アイテム機能', type: :system do
             expect(first('li')).to have_content item.genre
             expect(first('li')).to have_button '登録済み', disabled: true
           end
-        end.to change { user.items.count }.by(0)
+        end.not_to(change { user.items.count })
       end
     end
 
@@ -86,7 +86,7 @@ RSpec.describe 'アイテム機能', type: :system do
             first('li').click_on '追加'
           end
           expect(page).to have_content 'アイテムを追加することができませんでした'
-        end.to change { user.items.count }.by(0)
+        end.not_to(change { user.items.count })
       end
     end
 

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe '投稿機能', type: :system do
           expect(page).to have_content '※ 画像を選択して下さい'
           expect(page).to have_content '※ タグを選択してください'
           expect(page).to have_content '※ カテゴリーを選択してください'
-        end.to change { user.posts.count }.by(0)
+        end.not_to(change { user.posts.count })
       end
     end
 
@@ -88,7 +88,7 @@ RSpec.describe '投稿機能', type: :system do
           end
           expect(page).to have_content '※ タグは2つまで選択できます'
           expect(page).to have_content '※ カテゴリは2つまで選択できます'
-        end.to change { user.posts.count }.by(0)
+        end.not_to(change { user.posts.count })
       end
     end
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe 'ユーザー機能', type: :system do
           click_button '会員登録'
           expect(page).to have_current_path '/users'
           expect(page).to have_content 'パスワード（確認用）とパスワードの入力が一致しません'
-        end.to change(User, :count).by(0)
+        end.not_to change(User, :count)
       end
     end
 
@@ -120,7 +120,7 @@ RSpec.describe 'ユーザー機能', type: :system do
           click_button '会員登録'
           expect(page).to have_current_path '/users'
           expect(page).to have_content 'メールアドレスはすでに存在します'
-        end.to change(User, :count).by(0)
+        end.not_to change(User, :count)
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe 'ユーザー機能', type: :system do
           click_button '会員登録'
           expect(page).to have_current_path '/users'
           expect(page).to have_content 'プロフィール画像ファイルを5MBバイト以下のサイズにしてください'
-        end.to change(User, :count).by(0)
+        end.not_to change(User, :count)
       end
     end
   end
@@ -209,7 +209,7 @@ RSpec.describe 'ユーザー機能', type: :system do
       expect do
         click_on 'アカウント削除'
         expect(page).to have_content 'ゲストユーザーの削除・更新はできません'
-      end.to change(User, :count).by(0)
+      end.not_to change(User, :count)
     end
   end
 end


### PR DESCRIPTION
close #224
  
## 実装内容
- 投稿画像選択時に画像ファイルサイズが 5MB より大きい時、画像ファイル形式が`png`, `jpeg`, `jpg`以外の時は、その画像が保持されないようにする為に、`input`要素の`FileList`オブジェクトに`DataTransfer`オブジェクトの`files`プロパティ(FileList オブジェクト) を代入
```js
fileField.files = dataBox.files;
```
  
## 動作確認
- [ ] `rubocop -A`を実行してコードを修正
- [ ] `bundle exec rails_best_practices .`を実行
- [ ] `bundle exec rspec spec`を実行してテストが通過することを検証
  