### PR TITLE
投稿フォームの内容表示処理を修正

### DIFF
--- a/app/javascript/packs/photos_preview.js
+++ b/app/javascript/packs/photos_preview.js
@@ -74,17 +74,16 @@ $(document).on('turbolinks:load', function () {
       }
       const targetImage = $(this).parents("[class$='preview-item']");
       const targetId = $(targetImage).data('id');
-      $.each(fileField.files, function(i, file){
-        if(file.id === targetId){
-          dataBox.items.remove(i);
-          fileField.files = dataBox.files;
-          return false;
-        }
-      });
-      if(typeof(targetId) === 'string'){
-        const photoId = targetId.replace('photos-', '');
-        const deleteId = parseInt(photoId);
-        $('#edit-drop').before(`<input type="hidden" name="post_form[delete_ids][]" value="${deleteId}">`);
+      if($(targetImage).hasClass('preview-item')){
+        $.each(fileField.files, function(i, file){
+          if(file.id === targetId){
+            dataBox.items.remove(i);
+            fileField.files = dataBox.files;
+            return false;
+          }
+        });
+      }else{
+        $('#edit-drop').before(`<input type="hidden" name="post_form[delete_ids][]" value="${targetId}">`);
       }
       targetImage.remove();
       const previewItemLength = $(`#${action}-drop`).prevAll("[class$='preview-item']").length;

--- a/app/javascript/packs/post_edit.js
+++ b/app/javascript/packs/post_edit.js
@@ -8,64 +8,33 @@ $(document).on('turbolinks:load', function() {
       // 投稿内容を表示
       $('#edit_post_form_content').val(content)
       // 投稿画像を表示
-      const previewData = $('#edit-drop').prevAll('.edit-preview-item');
-      const targetIds = $.map(previewData, function(preview) {
-        return $(preview).data('id');
-      });
-      const photoIds = $.map(photos, function(photo) {
-        return photo.id;
-      });
-      if (targetIds.toString() !== photoIds.toString()) {
-        $('#edit-drop').prevAll().remove();
-        photos.forEach(function(photo){
-        const html = `<div class="edit-preview-item" data-id="${photo.id}">
-                        <img src="${photo.image.url}" class="preview-image">
-                        <button type="button" class="btn btn-dark-gray btn-sm rounded-circle delete-preview" data-action="edit"><i class="fas fa-times"></i></button>
-                      </div>`;
-          $('#edit-drop').before($(html));
-          const previewItemLength = $('#edit-drop').prevAll('.edit-preview-item').length;
-          if ( previewItemLength >= 1 && previewItemLength <= 6 ) {
-            $('#edit-button').prop('disabled', false);
-            if ( previewItemLength === 6 ) {
-              $('#edit-drop').hide();
-            }
+      $('#edit-drop').prevAll().remove();
+      photos.forEach(function(photo){
+      const html = `<div class="edit-preview-item" data-id="${photo.id}">
+                      <img src="${photo.image.url}" class="preview-image">
+                      <button type="button" class="btn btn-dark-gray btn-sm rounded-circle delete-preview" data-action="edit"><i class="fas fa-times"></i></button>
+                    </div>`;
+        $('#edit-drop').before($(html));
+        const previewItemLength = $('#edit-drop').prevAll('.edit-preview-item').length;
+        if ( previewItemLength >= 1 && previewItemLength <= 6 ) {
+          $('#edit-button').prop('disabled', false);
+          if ( previewItemLength === 6 ) {
+            $('#edit-drop').hide();
           }
-        });
-      }
+        }
+      });
 
+      $('.checkbox-visibility').prop('checked', false);
       // 投稿タグの表示
-      const checkedTag = $('.tags-check-box:checked');
-      const checkedTagIds = $.map(checkedTag, function(tag){
-        const previewTag = $(tag).val();
-        return parseInt(previewTag);
+      tags.forEach(function(tag){
+        const targetTag = $(`#edit_post_form_tag_ids_${tag.id}`);
+        $(targetTag).prop('checked', true);
       });
-      const tagIds = $.map(tags, function(tag){
-        return tag.id;
-      });
-      if(checkedTagIds.toString() !== tagIds.toString()){
-        $('.tags-check-box').prop('checked', false);
-        tags.forEach(function(tag){
-          const targetTag = $(`#edit_post_form_tag_ids_${tag.id}`);
-          $(targetTag).prop('checked', true);
-        });
-      }      
-
       // 投稿カテゴリーの表示
-      const checkedCategory = $('.categories-check-box:checked');
-      const checkedCategoryIds = $.map(checkedCategory, function(category){
-        const previewCategory = $(category).val();
-        return parseInt(previewCategory);
+      categories.forEach(function(category){
+        const targetCategory = $(`#edit_post_form_category_ids_${category.id}`);
+        $(targetCategory).prop('checked', true);
       });
-      const categoryIds = $.map(categories, function(category){
-        return category.id;
-      });
-      if(checkedCategoryIds.toString() !== categoryIds.toString()){
-        $('.categories-check-box').prop('checked', false);
-        categories.forEach(function(category){
-          const targetCategory = $(`#edit_post_form_category_ids_${category.id}`);
-          $(targetCategory).prop('checked', true);
-        });
-      }
     });
   });
 });

--- a/app/javascript/packs/post_edit.js
+++ b/app/javascript/packs/post_edit.js
@@ -18,7 +18,7 @@ $(document).on('turbolinks:load', function() {
       if (targetIds.toString() !== photoIds.toString()) {
         $('#edit-drop').prevAll().remove();
         photos.forEach(function(photo){
-        const html = `<div class="edit-preview-item" data-id="photos-${photo.id}">
+        const html = `<div class="edit-preview-item" data-id="${photo.id}">
                         <img src="${photo.image.url}" class="preview-image">
                         <button type="button" class="btn btn-dark-gray btn-sm rounded-circle delete-preview" data-action="edit"><i class="fas fa-times"></i></button>
                       </div>`;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
   <body>
     <%= render 'shared/header_top' %>
     <%= render 'shared/header_bottom' %>
-    <%= render 'shared/modal', action: 'new', title: '新規登録' %>
+    <%= render 'shared/modal', action: 'new', title: '新規投稿' %>
     <%= render 'shared/modal', action: 'search', title: '検索' %>
     <div id="flash-messages">
       <%= render 'layouts/flash_messages' %>

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe '投稿機能', type: :system do
         within '.modal-content' do
           find('label', text: post.tags[0].name).click
           find('label', text: post.categories[0].name).click
-          find("div[data-id='photos-#{post.photos[0].id}'] .delete-preview").click
+          find("div[data-id='#{post.photos[0].id}'].edit-preview-item .delete-preview").click
           find('#edit-button').click
         end
         expect(page).to have_content '※ キャプションを入力してください'


### PR DESCRIPTION
close #227
  
## 実装内容
- 画像削除の処理を簡素化する為に、投稿編集フォームでプレビュー画像に付与していた`data-id`属性の値変更
  - 編集フォームで表示していた保存済みの画像には`data-id="post-#{photo.id}"`を追加していたが`data-id="#{photo.id}"`に変更(新規投稿・編集共に`data-id`属性を数値で共通化)
  - 画像削除の際に保存済みの画像か判断する処理を`.preview-item`を含んでいるか否かで条件分岐するように修正(画像フォームから追加した画像にのみ`.preview-item`が追加され、保存済みの画像には`.edit-preview-item`が追加される)
- 投稿編集モーダルを開く直前に、「投稿画像」、「タグ」、「カテゴリ」を保存されている内容に置き換えるように修正
  - 保存済みの「タグ」、「カテゴリ」と現在モーダルにて選択されている「タグ」、「カテゴリ」の配列を作成して差異がある場合に保存済みの内容に置き換え初期値に戻していたが、簡素化・可読性を考慮して常に置き換えるように修正
- 投稿機能のシステムスペックで保存済みの画像か判断出来るように修正
- 投稿モーダルのタイトルを`新規投稿`に修正
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec`を実行してテストが通ることを確認