### PR TITLE
コメントのアカウント画像にユーザーページへのリンクを追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -93,6 +93,8 @@ button.close, button.navbar-toggler {
   position: relative;
   max-width: 160px;
   min-width: 32px;
+  margin-right: 8px;
+  margin-bottom: auto;
   .avatar-label {
     position: absolute;
     top: 0;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -104,16 +104,17 @@ button.close, button.navbar-toggler {
     background-size: cover;
     cursor: pointer;
   }
-  .user-avatar,.avatar-preview {
-    position: absolute;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
 }
 
-.avatar-container::before {
+.user-avatar,.avatar-preview {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.avatar-container::before,.comment-avatar-container::before {
   content: "";
   display: block;
   padding-top: 100%;

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -9,3 +9,10 @@
 .comment-user:hover {
   background-color: #f7f7f7;
 }
+
+.comment-avatar-container {
+  position: relative;
+  min-width: 24px;
+  margin-right: 8px;
+  margin-bottom: auto;
+}

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -29,7 +29,6 @@
 
 .card-user {
   padding: 16px;
-  margin-bottom: 16px;
   border-bottom: 1px solid $light-gray;
 }
 

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -26,6 +26,13 @@
     text-decoration: none;
   }
 }
+
+.card-user {
+  padding: 16px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid $light-gray;
+}
+
 .card-body {
   max-height: 600px;
 }

--- a/app/views/comments/_list.html.erb
+++ b/app/views/comments/_list.html.erb
@@ -1,10 +1,16 @@
 <div class="comment-user py-2 d-flex" id="comment-<%= comment.id %>">
-  <%= image_tag comment.user_avatar.url, class: "rounded-circle", size: "24x24" %>
   <div class="flex-column">
-    <div class="font-weight-bold">
-      <%= comment.user_name %>
+    <%= link_to user_path(comment.user), class: 'd-flex text-reset' do %>
+      <div class="mr-2">
+        <%= image_tag comment.user_avatar.url, class: "rounded-circle", size: "24x24" %>
+      </div>
+      <div class="font-weight-bold">
+        <%= comment.user_name %>
+      </div>
+    <% end %>
+    <div class="ml-4 pl-2">
+      <%= comment.content %>
     </div>
-    <%= comment.content %>
   </div>
   <% if comment.user == current_user %>
     <%= link_to "×", post_comment_path(comment.post, comment), class: "text-reset mr-3 ml-auto", method: :delete, remote: true, data: {confirm: "コメントを削除しますか?"} %>

--- a/app/views/comments/_list.html.erb
+++ b/app/views/comments/_list.html.erb
@@ -1,8 +1,8 @@
 <div class="comment-user py-2 d-flex" id="comment-<%= comment.id %>">
-  <div class="flex-column">
-    <%= link_to user_path(comment.user), class: 'd-flex text-reset' do %>
-      <div class="mr-2">
-        <%= image_tag comment.user_avatar.url, class: "rounded-circle", size: "24x24" %>
+  <div class="flex-column w-100">
+    <%= link_to user_path(comment.user), class: 'd-inline-flex text-reset mw-100' do %>
+      <div class="comment-avatar-container">
+        <%= image_tag comment.user_avatar.url, class: "user-avatar rounded-circle", size: "24x24" %>
       </div>
       <div class="font-weight-bold text-truncate">
         <%= comment.user_name %>

--- a/app/views/comments/_list.html.erb
+++ b/app/views/comments/_list.html.erb
@@ -4,7 +4,7 @@
       <div class="mr-2">
         <%= image_tag comment.user_avatar.url, class: "rounded-circle", size: "24x24" %>
       </div>
-      <div class="font-weight-bold">
+      <div class="font-weight-bold text-truncate">
         <%= comment.user_name %>
       </div>
     <% end %>

--- a/app/views/posts/_time_line.html.erb
+++ b/app/views/posts/_time_line.html.erb
@@ -10,17 +10,17 @@
         </div>
         <div class="col-md-6">
           <div class="card-body d-flex flex-column h-100 p-0">
-            <%= link_to user_path(post.user_id), class: 'text-reset' do %>
-              <div class="d-flex p-3">
-                <div class="avatar-container mr-2">
+            <div class="card-user">
+              <%= link_to user_path(post.user_id), class: 'd-inline-flex text-reset mw-100' do %>
+                <div class="avatar-container">
                   <%= image_tag post.user_avatar.url, class: "user-avatar rounded-circle", size: "32x32" %>
                 </div>
-                <div class="text-truncate">
+                <div class="font-weight-bold text-truncate">
                   <%= post.user_name %>
                 </div>
-              </div>
-            <% end %>
-            <div class="d-flex border-top px-3 py-2">
+              <% end %>
+            </div>
+            <div class="d-flex px-3 py-2">
               <div class="mr-4" id="post-<%= post.id %>-like">
                 <% if post.liked_by?(current_user) %>
                   <%= render "like", post: post %>

--- a/app/views/posts/_time_line.html.erb
+++ b/app/views/posts/_time_line.html.erb
@@ -15,7 +15,7 @@
                 <div class="avatar-container">
                   <%= image_tag post.user_avatar.url, class: "user-avatar rounded-circle", size: "32x32" %>
                 </div>
-                <div class="font-weight-bold text-truncate">
+                <div class="font-weight-bold text-truncate align-self-center">
                   <%= post.user_name %>
                 </div>
               <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -39,12 +39,12 @@
         <%# 投稿詳細を表示 %>
         <div class="col-md-12 col-xl-6">
           <div class="card-body d-flex flex-column h-100 p-0">
-            <div class="card-name d-flex p-3">
+            <div class="card-user d-flex">
               <%= link_to user_path(@post.user_id), class: "d-flex text-reset" do %>
                 <div class="avatar-container">
                   <%= image_tag @post.user_avatar.url, class: "user-avatar rounded-circle", size: "32x32" %>
                 </div>
-                <div class="font-weight-bold pl-2">
+                <div class="font-weight-bold text-break">
                   <%= @post.user_name %>
                 </div>
               <% end %>
@@ -62,7 +62,7 @@
                 </div>
               <% end %>
             </div>
-            <small class="d-flex flex-wrap border-top p-3">
+            <small class="d-flex flex-wrap px-3">
               <div class="pr-2">
                 <i class="fas fa-tag tag-color"></i>
                 <% @post.tags.each do |tag| %>
@@ -80,7 +80,7 @@
                 <% end %>
               </div>
             </small>
-            <div class="card-content overflow-auto h-100 px-3">
+            <div class="card-content overflow-auto h-100 p-3">
               <div class="card-text">
                 <%= simple_format(h @post.content) %>
               </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -44,7 +44,7 @@
                 <div class="avatar-container">
                   <%= image_tag @post.user_avatar.url, class: "user-avatar rounded-circle", size: "32x32" %>
                 </div>
-                <div class="font-weight-bold text-break">
+                <div class="font-weight-bold text-break align-self-center">
                   <%= @post.user_name %>
                 </div>
               <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -40,12 +40,14 @@
         <div class="col-md-12 col-xl-6">
           <div class="card-body d-flex flex-column h-100 p-0">
             <div class="card-name d-flex p-3">
-            <%= link_to user_path(@post.user_id), class: "d-flex text-reset" do %>
-              <%= image_tag @post.user_avatar.url, class: "rounded-circle", size: "32x32" %>
-              <div class="font-weight-bold pl-2">
-                <%= @post.user_name %>
-              </div>
-            <% end %>
+              <%= link_to user_path(@post.user_id), class: "d-flex text-reset" do %>
+                <div class="avatar-container">
+                  <%= image_tag @post.user_avatar.url, class: "user-avatar rounded-circle", size: "32x32" %>
+                </div>
+                <div class="font-weight-bold pl-2">
+                  <%= @post.user_name %>
+                </div>
+              <% end %>
               <% if current_user.id == @post.user_id %>
                 <div class="dropdown ml-auto">
                   <div class="btn btn-dark-gray dropdown-toggle btn-sm" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -63,7 +63,7 @@
               <% end %>
             </div>
             <small class="d-flex flex-wrap px-3">
-              <div class="pr-2">
+              <div class="pt-2">
                 <i class="fas fa-tag tag-color"></i>
                 <% @post.tags.each do |tag| %>
                   <span class="pr-2">
@@ -71,7 +71,7 @@
                   </span>
                 <% end %>
               </div>
-              <div class="pr-2">
+              <div class="pt-2">
                 <i class="fas fa-folder category-color"></i>
                 <% @post.categories.each do |category| %>
                   <span class="pr-2">


### PR DESCRIPTION
close #229
  
## 実装内容
- コメントしたユーザーのプロフィール画像にユーザーページへのリンクを設定する
  - ユーザーページへ遷移できるようにすることで`UX`の向上につなげる為
- コメントしたユーザーネームが長い場合省略される様にスタイルを追加
- 投稿詳細ページのに表示されている、投稿したユーザーとコメントしたユーザーのプロフィール画像のサイズが崩れないように css を使用してスタイルを設定
- ユーザーネームがブロックの上下中央に配置されるように修正(align-self: center;)
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec`を実行