### PR TITLE
投稿画像のプレビュー処理を関数を使用して共通化

### DIFF
--- a/app/javascript/packs/photos_preview.js
+++ b/app/javascript/packs/photos_preview.js
@@ -6,24 +6,7 @@ $(document).on('turbolinks:load', function () {
     let new_file_field = document.querySelector('input[data-action=new]');
     const maxFileSize = 1048576 * 5;
     const mimeType = ['image/jpeg', 'image/png'];
-    // 画像選択時にプレビューを表示
-    $('.post-file-field').on("change", function(){
-      let dataBox, fileField
-      const action = $(this).data('action');
-      if (action === "edit") {
-        dataBox = editDataBox
-        fileField = edit_file_field
-      } else {
-        dataBox = newDataBox
-        fileField = new_file_field
-      }
-      // 選択をキャンセルした場合の処理
-      if ($(this).val() === "") {
-        $('.preview-item').remove();
-        fileField.files = dataBox.files
-        dataBox.clearData();
-      }
-      const files = $(this).prop('files');
+    function postsPreview(files, action, dataBox, fileField){
       $.each(files, function(i, file){
         if(maxFileSize < file.size){
           // 画像ファイルが 5MB より大きい場合の処理
@@ -60,6 +43,26 @@ $(document).on('turbolinks:load', function () {
           };
         }
       });
+    }
+    // 画像選択時のプレビュー表示
+    $('.post-file-field').on("change", function(){
+      let dataBox, fileField
+      const action = $(this).data('action');
+      if (action === "edit") {
+        dataBox = editDataBox
+        fileField = edit_file_field
+      } else {
+        dataBox = newDataBox
+        fileField = new_file_field
+      }
+      // 画像選択でキャンセルした場合
+      if ($(this).val() === "") {
+        $('.preview-item').remove();
+        fileField.files = dataBox.files
+        dataBox.clearData();
+      }
+      const files = $(this).prop('files');
+      postsPreview(files, action, dataBox, fileField);
     });
     // 画像の削除
     $('.preview-box').on("click", '.delete-preview', function(){
@@ -97,7 +100,7 @@ $(document).on('turbolinks:load', function () {
         }
       }
     });
-
+    // 画像ドロップ時のプレビュー表示
     $('.modal').on('show.bs.modal', function (e) {
       let dropArea;
       const modalAction = this.id
@@ -130,40 +133,7 @@ $(document).on('turbolinks:load', function () {
         e.preventDefault();
         $(this).css({'border': '2px dashed $dark-gray', 'opacity': '1.0'});
         const files = e.dataTransfer.files;
-        $.each(files, function(i, file){
-          if(maxFileSize < file.size){
-            // 画像ファイルが 5MB より大きい場合の処理
-            alert('画像ファイルは最大 5MB 以下にしてください');
-          } else if (!mimeType.includes(file.type)){
-            // 画像ファイルが .jpeg, .jpg, .png 以外の場合の処理
-            alert('画像ファイルは .jpg, .jpeg, .png のみアップロードできます');
-          } else {
-            const fileReader = new FileReader();
-            const lastFileId = dataBox.files.length === 0 ? 0 : $(dataBox.files).last()[0].id;
-            file.id = lastFileId + 1;
-            dataBox.items.add(file)
-            fileField.files = dataBox.files
-            fileReader.readAsDataURL(file);
-            fileReader.onloadend = function() {
-              const html = `<div class="preview-item" data-id="${file.id}">
-                          <img src="${fileReader.result}" class="preview-image">
-                          <button type="button" class="btn btn-dark-gray btn-sm rounded-circle delete-preview" data-action="${action}"><i class="fas fa-times"></i></button>
-                        </div>`;
-              $(`#${action}-drop`).before($(html));
-              const previewItemLength = $(`#${action}-drop`).prevAll("[class$='preview-item']").length;
-              if (previewItemLength > 0){
-                $("[id$='post_form_images-error']").css('display', 'none');
-                if ( previewItemLength >= 6 ){
-                  $(`#${action}-drop`).hide();
-                  if ( previewItemLength === 7 ){
-                    $(`#${action}-button`).prop('disabled', true);
-                    alert('画像は最大 6枚 にしてください');
-                  }
-                }
-              }
-            };
-          }
-        });
+        postsPreview(files, action, dataBox, fileField);
       });
     });
   });


### PR DESCRIPTION
close #231
  
## 実装内容
- 冗長化を解消するために、フォームからの画像選択及びフォームへの画像ドロップ時のプレビュー表示の処理を関数を使用して定義して共通化
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec`を実行してテストが通過することを確認
- [x] ローカル環境で画像の投稿・編集ができることを確認