### PR TITLE
投稿画像選択されているか否か判断する条件分岐を簡素化

### DIFF
--- a/app/javascript/packs/photos_preview.js
+++ b/app/javascript/packs/photos_preview.js
@@ -55,14 +55,12 @@ $(document).on('turbolinks:load', function () {
         dataBox = newDataBox
         fileField = new_file_field
       }
-      // 画像選択でキャンセルした場合
-      if ($(this).val() === "") {
-        $('.preview-item').remove();
+      if ($(this).val()) {
+        const files = $(this).prop('files');
+        postsPreview(files, action, dataBox, fileField);
+      } else {
         fileField.files = dataBox.files
-        dataBox.clearData();
       }
-      const files = $(this).prop('files');
-      postsPreview(files, action, dataBox, fileField);
     });
     // 画像の削除
     $('.preview-box').on("click", '.delete-preview', function(){


### PR DESCRIPTION
close #233
  
## 実装内容
- 画像が選択されていない場合でも再度プレビュー処理をしてしまっており冗長化してしまっている部分を解消
  - プレビューの削除と`DataTransfer`オブジェクトの削除の2つの処理を削除
  - 画像が選択されている場合のみ、プレビュー処理を実行する
  - 画像が選択されていない場合は、すでに選択されている画像を代入して`DataTransfer`オブジェクトの`files`と`input`要素の`FileList`の差異を無くすだけの処理に変更。
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec`を実行してテストが通過することを確認
- [x] ローカル環境で問題なく画像が投稿できることを確認