### PR TITLE
ユーザーネームが長い場合にレイアウトが崩れてしまわない様に修正 #236

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -4,8 +4,11 @@
 
 @import 'valiables';
 
-.user-name {
+.profile-name {
   font-size: 20px;
+  overflow-wrap: break-word;
+  font-weight: bold;
+  margin-bottom: 16px;
 }
 
 .user-info {
@@ -65,7 +68,7 @@
 }
 
 @media (min-width: 576px) {
-  .user-name {
+  .profile-name {
     font-size: 24px;
   }
   .user-info {

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,18 +8,16 @@
   <div class="col-12 col-xl-6 d-flex flex-column h-100">
     <div class="d-flex flex-column mb-4">
       <div class="row no-gutters mb-3 mb-sm-0">
-        <div class="col-3 mr-3">
+        <div class="col-3">
           <div class="avatar-container mx-auto">
             <%= image_tag @user.avatar.url, class: "rounded-circle user-avatar bg-light" %>
           </div>
         </div>
-        <div class="col d-flex flex-column">
-          <div class="d-flex">
-            <div class="font-weight-bold user-name mb-3">
-              <%= @user.name %>
-            </div>
+        <div class="col-9 d-flex flex-column">
+          <div class="profile-name pl-3">
+            <%= @user.name %>
           </div>
-          <div class="user-info text-muted">
+          <div class="user-info text-muted pl-3">
             <ul class="d-flex flex-wrap pl-0">
               <li class="pr-3 pr-sm-5">
                 <i class="fas fa-house-user mr-1"></i><%= @user.household_i18n %>


### PR DESCRIPTION
close #236
  
## 実装内容
- ユーザーページにて、ユーザーネームの長さによってレイアウトが崩れてしまっている為、常にプロフィール画像とユーザーネームが横並びで表示される様に修正
  - ユーザーネームが長い場合は、折り返して表示される様にする事
  - プロフィール画像とユーザーネーム間の`margin`を削除して、グリッドクラスを指定
  - ユーザーネームとユーザー情報のブロック要素に`padding-left`を指定して、プロフィール画像との余白を確保
  
## 動作確認
- [ ] `rubocop -A`を実行
- [ ] `bundle exec rails_best_practices .`を実行
- [ ] `bundle exec rspec spec`を実行してテストが通過することを確認