### PR TITLE
トップページの Pick Up で表示している画像サイズを修正

### DIFF
--- a/app/views/homes/_pick_up.html.erb
+++ b/app/views/homes/_pick_up.html.erb
@@ -1,4 +1,4 @@
-<div class="col-11 col-sm-7 col-md-5 col-lg-3 mb-3">
+<div class="col-7 col-md-5 col-lg-3 mb-3">
   <%= link_to post, class: "text-reset" do %>
     <div class="card text-black-50">
       <%= image_tag post.photos.first.image.url, class: "img-fluid", width: "1080px", height: "1080px" %>


### PR DESCRIPTION
close #238
  
## 実装内容
- UI を整えるためにトップページの「ピックアップ」で表示している画像サイズを修正
  - グリッドシステムを使用してブレークポイントを設定
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec`を実行してテストが通る事を検証