### PR TITLE
家具・家電追加機能を非同期で実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,22 +10,30 @@ class ItemsController < ApplicationController
 
   def create
     @item = current_user.items.build(item_params)
+    @product_id = params[:product_id]
     if @item.save
-      redirect_to user_items_path, notice: "#{@item.name} をマイアイテムに追加しました"
+      flash.now[:notice] = "#{@item.name} を追加しました"
     else
-      redirect_to user_items_path, alert: 'アイテムを追加することができませんでした'
+      flash.now[:alert] = "#{@item.name} を追加することができませんでした"
     end
   end
 
   def destroy
-    @item.destroy!
-    flash.now[:alert] = "#{@item.name} を削除しました"
+    item = current_user.items.find(params[:id])
+    item.destroy!
+    flash.now[:alert] = "#{item.name} を削除しました"
   end
 
   private
 
   def set_item
-    @item = current_user.items.find(params[:id])
+    @item = {
+      'id' => params[:id],
+      'productName' => params[:name],
+      'genreName' => params[:genre],
+      'mediumImageUrl' => params[:remote_image_url],
+      'productId' => params[:product_id]
+    }
   end
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -14,7 +14,7 @@ class ItemsController < ApplicationController
     if @item.save
       flash.now[:notice] = "#{@item.name} を追加しました"
     else
-      flash.now[:alert] = "#{@item.name} を追加することができませんでした"
+      render :error_messages
     end
   end
 

--- a/app/helpers/search_items_helper.rb
+++ b/app/helpers/search_items_helper.rb
@@ -2,4 +2,8 @@ module SearchItemsHelper
   def registered_item?(item_name)
     current_user.items.any? { |item| item.name == item_name }
   end
+
+  def to_item_id(item_name)
+    current_user.items.find_by(name: item_name).id
+  end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -73,7 +73,7 @@
     <%= f.check_box :agreement, class: "form-check-input ml-0 agreement", required: true %>
     <%= f.label :agreement, class: 'form-check-label' do %>
       <span class="ml-4">
-        <%= link_to "利用規約", page_path('terms_of_use'), target: "_blank" %>と<%= link_to "プライバシーポリシー", page_path('privacy_policy'), target: "_blank" %>についてに同意する
+        <%= link_to "利用規約", page_path('terms_of_use'), target: "_blank" %>と<%= link_to "プライバシーポリシー", page_path('privacy_policy'), target: "_blank" %>について同意する
       </span>
     <% end %>
   </div>

--- a/app/views/items/create.js.erb
+++ b/app/views/items/create.js.erb
@@ -1,2 +1,3 @@
-document.getElementById("<%= @product_id %>").innerHTML = '<%= j render("search_items/erasure", item: {id: @item.id, name: @item.name, genre: @item.genre, remote_image_url: @item.remote_image_url, product_id: @product_id}) %>'
-document.getElementById('flash-messages').innerHTML = '<%= j render("layouts/flash_messages") %>'
+document.getElementById("<%= @product_id %>").innerHTML = '<%= j render("search_items/erasure", item: {id: @item.id, name: @item.name, genre: @item.genre, remote_image_url: @item.remote_image_url, product_id: @product_id}) %>';
+document.getElementById('flash-messages').innerHTML = '<%= j render("layouts/flash_messages") %>';
+document.getElementById('item-error-messages').textContent = '';

--- a/app/views/items/create.js.erb
+++ b/app/views/items/create.js.erb
@@ -1,0 +1,2 @@
+document.getElementById("<%= @product_id %>").innerHTML = '<%= j render("search_items/erasure", item: {id: @item.id, name: @item.name, genre: @item.genre, remote_image_url: @item.remote_image_url, product_id: @product_id}) %>'
+document.getElementById('flash-messages').innerHTML = '<%= j render("layouts/flash_messages") %>'

--- a/app/views/items/destroy.js.erb
+++ b/app/views/items/destroy.js.erb
@@ -1,7 +1,8 @@
-productId = document.getElementById('<%= @item["productId"] %>')
+productId = document.getElementById('<%= @item["productId"] %>');
 if(productId) {
-  productId.innerHTML = '<%= j render("search_items/register", item: @item) %>'
+  productId.innerHTML = '<%= j render("search_items/register", item: @item) %>';
 } else {
   document.getElementById('my-item-<%= @item["id"] %>').remove();
 }
-document.getElementById('flash-messages').innerHTML = '<%= j render("layouts/flash_messages") %>'
+document.getElementById('flash-messages').innerHTML = '<%= j render("layouts/flash_messages") %>';
+document.getElementById('item-error-messages').textContent = '';

--- a/app/views/items/destroy.js.erb
+++ b/app/views/items/destroy.js.erb
@@ -1,2 +1,7 @@
-document.getElementById('my-item-<%= @item.id %>').remove();
-document.getElementById('flash-messages').innerHTML = '<%= j render("layouts/flash_messages") %>';
+productId = document.getElementById('<%= @item["productId"] %>')
+if(productId) {
+  productId.innerHTML = '<%= j render("search_items/register", item: @item) %>'
+} else {
+  document.getElementById('my-item-<%= @item["id"] %>').remove();
+}
+document.getElementById('flash-messages').innerHTML = '<%= j render("layouts/flash_messages") %>'

--- a/app/views/items/error_messages.js.erb
+++ b/app/views/items/error_messages.js.erb
@@ -1,0 +1,2 @@
+document.getElementById('item-error-messages').innerHTML = '<%= j render("layouts/error_messages", model: @item) %>';
+document.getElementById('flash-messages').innerHTML = '<%= j render("layouts/flash_messages") %>';

--- a/app/views/search_items/_erasure.html.erb
+++ b/app/views/search_items/_erasure.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "削除", user_item_path(current_user, item), method: :delete, type: "button", class: "btn btn-dark-gray w-100", remote: true %>

--- a/app/views/search_items/_register.html.erb
+++ b/app/views/search_items/_register.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "追加", user_items_path(current_user, product_id: item["productId"], item: {name: item["productName"], genre: item["genreName"], remote_image_url: item["mediumImageUrl"]}), method: :post, type: "button", class: "btn btn-outline-main w-100", remote: true %>

--- a/app/views/search_items/_search_item.html.erb
+++ b/app/views/search_items/_search_item.html.erb
@@ -11,11 +11,13 @@
           <h6 class="px-2"><%= item["productName"] %></h6>
           <p class="text-muted px-2"><%= item["genreName"] %></p>
         <% end %>
-        <% if registered_item?(item["productName"]) %>
-          <%= button_tag "登録済み", disabled: true, class: "btn btn-dark-gray mx-lg-2" %>
-        <% else %>
-          <%= link_to "追加", user_items_path(current_user, item: {name: item["productName"], genre: item["genreName"], remote_image_url: item["mediumImageUrl"]}), method: :post, type: "button", class: "btn btn-outline-main mx-lg-2", data: { disable_with: "追加..."} %>
-        <% end %>
+        <div id="<%= item["productId"] %>">
+          <% if registered_item?(product_name = item["productName"]) %>
+            <%= render "erasure", item: {id: to_item_id(product_name), name: item["productName"], genre: item["genreName"], remote_image_url: item["mediumImageUrl"], product_id: item["productId"]} %>
+          <% else %>
+            <%= render "register", item: item %>
+          <% end %>
+        </div>
       </li>
     <% end %>
   </ul>

--- a/app/views/search_items/index.html.erb
+++ b/app/views/search_items/index.html.erb
@@ -6,6 +6,7 @@
   </div>
 </div>
 <%= form_with url: search_items_path, method: :get, local: false do |form| %>
+  <div id="item-error-messages"></div>
   <div class="form-group">
     <div class="input-group">
       <%= form.text_field :keyword, class: "form-control", placeholder: "追加したいアイテムを検索", value: params[:keyword], required: true %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -154,11 +154,11 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context '利用規約に同意していないとき' do
-      let(:user) { build(:user, terms_of_use: '0') }
+    context '利用規約とプライバシーポリシーに同意していないとき' do
+      let(:user) { build(:user, agreement: '0') }
       it 'エラーが発生する' do
         expect(subject).to be false
-        expect(user.errors.messages[:terms_of_use]).to include 'について同意してください'
+        expect(user.errors.messages[:agreement]).to include 'について同意してください'
       end
     end
   end

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -9,83 +9,108 @@ RSpec.describe 'アイテム機能', type: :system do
     visit user_items_path(user)
   end
 
+  describe 'マイアイテム一覧機能' do
+    let(:user) { create(:user) }
+    before do
+      @item = create(:item, user: user)
+    end
+
+    context 'マイアイテムページへ遷移したとき' do
+      it '登録済みのアイテムが表示されること' do
+        visit user_items_path(user)
+        within "#my-item-#{@item.id}" do
+          expect(page).to have_selector "img[src='#{@item.image.url}']"
+          expect(page).to have_content @item.name
+          expect(page).to have_content @item.genre
+        end
+      end
+    end
+  end
+
   describe 'アイテム追加機能' do
     let(:user) { create(:user) }
     context '検索したアイテムの追加ボタンを押下したとき' do
       let(:item) { build(:item, user: user) }
-      it 'そのアイテムがマイアイテムに追加されること' do
+      it 'そのアイテムがマイアイテムに追加されること', js: true do
         visit user_items_path(user)
-        product = [{ 'affiliateUrl' => Faker::Internet.url, 'mediumImageUrl' => item.remote_image_url, 'productName' => item.name, 'genreName' => item.genre }]
+        product = [{
+          'affiliateUrl' => Faker::Internet.url,
+          'mediumImageUrl' => item.remote_image_url,
+          'productName' => item.name,
+          'genreName' => item.genre,
+          'productId' => Faker::Number.number,
+          'id' => Faker::Number.number
+        }]
         search_items_mock = class_double(RakutenWebService::Ichiba::Product)
         allow(search_items_mock).to receive(:search)
         allow(RakutenWebService::Ichiba::Product).to receive(:search).and_return(product)
         expect { search_items_mock.search }.not_to raise_error
         expect do
-          within '.search-item-group' do
-            click_on 'アイテムを追加する'
-            fill_in 'keyword', with: item.name
-            find('.input-group-append button').click
-          end
+          fill_in 'keyword', with: item.name
+          find('.input-group-append button').click
           within '#search-item-list' do
             expect(first('li')).to have_selector "img[src='#{item.remote_image_url}']"
             expect(first('li')).to have_content item.name
             expect(first('li')).to have_content item.genre
             first('li').click_on '追加'
           end
-          expect(page).to have_content "#{item.name} をマイアイテムに追加しました"
-          within "#my-item-#{user.items.last.id}" do
-            expect(page).to have_selector "img[src='#{user.items.last.image.url}']"
-            expect(page).to have_content item.name
-            expect(page).to have_content item.genre
-          end
+          expect(page).to have_content "#{item.name} を追加しました"
         end.to change { user.items.count }.by(1)
       end
     end
 
     context 'アイテムが既に登録済みのとき' do
       let(:item) { create(:item, image: nil, user: user) }
-      it 'ボタンが【登録済み】と表示されること' do
+      it '削除ボタンが表示されること' do
         visit user_items_path(user)
-        product = [{ 'affiliateUrl' => Faker::Internet.url, 'mediumImageUrl' => item.remote_image_url, 'productName' => item.name, 'genreName' => item.genre }]
+        product = [{
+          'affiliateUrl' => Faker::Internet.url,
+          'mediumImageUrl' => item.remote_image_url,
+          'productName' => item.name,
+          'genreName' => item.genre,
+          'productId' => Faker::Number.number,
+          'id' => Faker::Number.number
+        }]
         search_items_mock = class_double(RakutenWebService::Ichiba::Product)
         allow(search_items_mock).to receive(:search)
         allow(RakutenWebService::Ichiba::Product).to receive(:search).and_return(product)
         expect { search_items_mock.search }.not_to raise_error
         expect do
-          within '.search-item-group' do
-            click_on 'アイテムを追加する'
-            fill_in 'keyword', with: item.name
-            find('.input-group-append button').click
-          end
+          fill_in 'keyword', with: item.name
+          find('.input-group-append button').click
           within '#search-item-list' do
             expect(first('li')).to have_selector "img[src='#{item.remote_image_url}']"
             expect(first('li')).to have_content item.name
             expect(first('li')).to have_content item.genre
-            expect(first('li')).to have_button '登録済み', disabled: true
+            expect(first('li')).to have_content '削除'
           end
         end.not_to(change { user.items.count })
       end
     end
 
-    context 'アイテム追加の条件を満たさないとき' do
-      let(:item) { build(:item, name: nil, user: user) }
+    context 'アイテム追加の条件を満たさないとき', js: true do
+      let(:item) { build(:item, user: user) }
       it 'エラーが発生すること' do
         visit user_items_path(user)
-        product = [{ 'affiliateUrl' => Faker::Internet.url, 'mediumImageUrl' => item.remote_image_url, 'productName' => item.name, 'genreName' => item.genre }]
+        product = [{
+          'affiliateUrl' => Faker::Internet.url,
+          'mediumImageUrl' => item.remote_image_url,
+          'productName' => nil,
+          'genreName' => item.genre,
+          'productId' => Faker::Number.number,
+          'id' => Faker::Number.number
+        }]
         search_items_mock = class_double(RakutenWebService::Ichiba::Product)
         allow(search_items_mock).to receive(:search)
         allow(RakutenWebService::Ichiba::Product).to receive(:search).and_return(product)
         expect { search_items_mock.search }.not_to raise_error
         expect do
-          within '.search-item-group' do
-            click_on 'アイテムを追加する'
-            fill_in 'keyword', with: 'テストアイテム'
-            find('.input-group-append button').click
-          end
+          fill_in 'keyword', with: item.name
+          find('.input-group-append button').click
           within '#search-item-list' do
             first('li').click_on '追加'
           end
-          expect(page).to have_content 'アイテムを追加することができませんでした'
+          expect(page).to have_content 'アイテム名を入力してください'
         end.not_to(change { user.items.count })
       end
     end
@@ -99,18 +124,46 @@ RSpec.describe 'アイテム機能', type: :system do
   end
 
   describe 'アイテム削除機能' do
-    context 'アイテム削除ボタンを押下したとき' do
-      let(:user) { create(:user) }
-      before do
-        @item = create(:item, user: user)
-      end
+    let(:user) { create(:user) }
+    before do
+      @item = create(:item, user: user)
+    end
 
+    context 'マイアイテムページから削除したとき' do
       it 'そのアイテムがマイアイテムから削除されること', js: true do
         visit user_items_path(user)
         expect do
           click_on "my-item-menu-#{@item.id}"
           click_on '削除'
           page.accept_confirm
+          expect(page).to have_content "#{@item.name} を削除しました"
+        end.to change { user.items.count }.by(-1)
+      end
+    end
+
+    context 'アイテム検索ページから削除したとき' do
+      it '削除ボタンから追加ボタンに切り替わること', js: true do
+        visit user_items_path(user)
+        product = [{
+          'affiliateUrl' => Faker::Internet.url,
+          'mediumImageUrl' => @item.remote_image_url,
+          'productName' => @item.name,
+          'genreName' => @item.genre,
+          'productId' => Faker::Number.number,
+          'id' => Faker::Number.number
+        }]
+        search_items_mock = class_double(RakutenWebService::Ichiba::Product)
+        allow(search_items_mock).to receive(:search)
+        allow(RakutenWebService::Ichiba::Product).to receive(:search).and_return(product)
+        expect { search_items_mock.search }.not_to raise_error
+        expect do
+          fill_in 'keyword', with: @item.name
+          find('.input-group-append button').click
+          within '#search-item-list' do
+            expect(first('li')).to have_content '削除'
+            first('li').click_on '削除'
+            expect(first('li')).to have_content '追加'
+          end
           expect(page).to have_content "#{@item.name} を削除しました"
         end.to change { user.items.count }.by(-1)
       end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'ユーザー機能', type: :system do
       select user.age_i18n, from: '年代'
       select user.address_i18n, from: 'お住まい'
       select user.household_i18n, from: '家族構成'
-      check '利用規約について同意する'
+      check '利用規約とプライバシーポリシーについて同意する'
     end
 
     context '入力情報が条件を満たすとき' do


### PR DESCRIPTION
close #244
  
## 実装内容
- アイテム検索ページにて非同期で追加・削除できる様にボタンを実装
  - `js.erb`ファイルを使用してボタンの差し替え、フラッシュメッセージを非同期で表示
- 登録済みアイテムのインスタンスを取得するヘルパーメソッドを作成
- バリデーションエラーメッセージを非同期で表示
  - `items/errors_messages.js.erb`を追加して、バリデーションエラーが発生した際にメッセージを挿入
- アイテム機能のシステムスペックを追加・修正
- 会員登録時のモデルスペック・システムスペックを修正
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec`を実行してテストが通過することを確認
- [x] ローカル環境で期待した通りに動作することを確認