### PR TITLE
コメント送信ボタンの位置を修正

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -6,8 +6,16 @@
   resize: none;
 }
 
-.comment-user:hover {
-  background-color: #f7f7f7;
+.comment-user {
+  font-weight: bold;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.comment-content {
+  padding-left: 32px;
 }
 
 .comment-avatar-container {

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -2,8 +2,9 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
-.comment-form {
+#comment-area {
   resize: none;
+  max-height: 300px;
 }
 
 .comment-user {

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -3,6 +3,9 @@
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
 #comment-area {
+  outline: none;
+  border: none;
+  box-shadow: none;
   resize: none;
   max-height: 300px;
 }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -21,6 +21,6 @@ class CommentsController < ApplicationController
   end
 
   def comment_params
-    params.required(:comment).permit(:content, :user_id, :post_id)
+    params.required(:comment).permit(:content).merge(user_id: current_user.id)
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -26,6 +26,7 @@ import "./search"
 import "chartkick/highcharts"
 import "./collapse"
 import "./post-show"
+import "./comment"
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/packs/comment.js
+++ b/app/javascript/packs/comment.js
@@ -1,0 +1,7 @@
+document.addEventListener('turbolinks:load', () => {
+  let textarea = document.getElementById('comment-area');
+  textarea.addEventListener('input', ()=>{
+      textarea.style.height = 'auto';
+      textarea.style.height = textarea.scrollHeight + 'px';
+  });
+})

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,9 +1,11 @@
-<%= form_with model: [post, comment], class: "form-inline", local: false do |form| %>
+<%= form_with model: [post, comment], local: false do |form| %>
   <div class="w-100" id="comment-error-messages">
     <%= render "layouts/error_messages", model: comment %>
   </div>
   <div class="form-group w-100">
-    <%= form.text_area :content, class: "form-control flex-grow-1", id: "comment-area", placeholder: "コメント...", required: true, maxlength: 140, rows: "1" %>
-    <%= form.submit "送信する", class: "btn btn-main mt-auto" %>
+    <%= form.label :content, class: "border rounded w-100 mb-0", for: "comment-area" do %>
+      <%= form.text_area :content, class: "form-control flex-grow-1", id: "comment-area", placeholder: "コメント...", required: true, maxlength: 140, rows: "1" %>
+      <%= form.submit "送信", class: "d-flex btn btn-main btn-sm mt-auto ml-auto" %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -3,8 +3,6 @@
     <%= render "layouts/error_messages", model: comment %>
   </div>
   <div class="form-group w-100">
-    <%= form.hidden_field :user_id, value: current_user.id %>
-    <%= form.hidden_field :post_id, value: post.id %>
     <%= form.text_area :content, class: "form-control comment-form flex-grow-1", placeholder: "コメント...", required: true, maxlength: 140, rows: "1" %>
     <%= form.submit "送信する", class: "btn btn-main ml-auto" %>
   </div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -3,7 +3,7 @@
     <%= render "layouts/error_messages", model: comment %>
   </div>
   <div class="form-group w-100">
-    <%= form.text_area :content, class: "form-control comment-form flex-grow-1", placeholder: "コメント...", required: true, maxlength: 140, rows: "1" %>
-    <%= form.submit "送信する", class: "btn btn-main ml-auto" %>
+    <%= form.text_area :content, class: "form-control flex-grow-1", id: "comment-area", placeholder: "コメント...", required: true, maxlength: 140, rows: "1" %>
+    <%= form.submit "送信する", class: "btn btn-main mt-auto" %>
   </div>
 <% end %>

--- a/app/views/comments/_list.html.erb
+++ b/app/views/comments/_list.html.erb
@@ -1,18 +1,18 @@
-<div class="comment-user py-2 d-flex" id="comment-<%= comment.id %>">
-  <div class="flex-column w-100">
-    <%= link_to user_path(comment.user), class: 'd-inline-flex text-reset mw-100' do %>
+<div class="flex-column mb-2 w-100" id="comment-<%= comment.id %>">
+  <div class="d-flex">
+    <%= link_to user_path(comment.user), class: 'd-flex text-reset overflow-hidden' do %>
       <div class="comment-avatar-container">
         <%= image_tag comment.user_avatar.url, class: "user-avatar rounded-circle", size: "24x24" %>
       </div>
-      <div class="font-weight-bold text-truncate">
+      <div class="comment-user">
         <%= comment.user_name %>
       </div>
     <% end %>
-    <div class="ml-4 pl-2">
-      <%= comment.content %>
-    </div>
+    <% if comment.user == current_user %>
+      <%= link_to "×", post_comment_path(comment.post, comment), class: "text-reset pr-3 ml-auto", method: :delete, remote: true, data: {confirm: "コメントを削除しますか?"} %>
+    <% end %>
   </div>
-  <% if comment.user == current_user %>
-    <%= link_to "×", post_comment_path(comment.post, comment), class: "text-reset mr-3 ml-auto", method: :delete, remote: true, data: {confirm: "コメントを削除しますか?"} %>
-  <% end %>
+  <div class="comment-content">
+    <%= comment.content %>
+  </div>
 </div>

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -30,7 +30,7 @@ pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY") { 4 }
+workers ENV.fetch('WEB_CONCURRENCY', 4)
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe 'コメント機能', type: :system do
             expect(page).not_to have_content comment.content
           end
           within '.comment-group' do
-            find('#comment_content').set(comment.content)
-            click_on '送信する'
+            find('#comment-area').set(comment.content)
+            click_on '送信'
           end
           within '.comment-container' do
             expect(page).to have_content comment.content
@@ -56,8 +56,8 @@ RSpec.describe 'コメント機能', type: :system do
         visit post_path(post)
         expect do
           within '.comment-group' do
-            find('#comment_content').set('')
-            click_on '送信する'
+            find('#comment-area').set('')
+            click_on '送信'
           end
         end.not_to(change { post.comments.count })
       end


### PR DESCRIPTION
close #249
  
## 実装内容
- `JavaScript`を使用して、コメント入力欄の高さが自動調節するように処理を追加
- コメント送信ボタンの表示位置とスタイルを修正
- `Rubocop`に従い、Pumaの設定ファイルの記述を変更
- コメント送信時に`hiddden_field`で送信していた`user_id`, `post_id`を排除して、ストロングパラメータでマージするように修正
  
##  動作確認
- [ ] `rubocop -A`を実行
- [ ] `bundle exec rails_best_practices .`を実行
- [ ] `bundle exec rspec spec`を実行して、テストが通過することを確認